### PR TITLE
Add ClinicalTrials.gov dataset fetchers

### DIFF
--- a/data_fetch/build_clinical_trials_dataset.py
+++ b/data_fetch/build_clinical_trials_dataset.py
@@ -1,0 +1,273 @@
+"""Build reusable datasets from ClinicalTrials.gov for the R&D dashboard.
+
+The goal of the script is to provide a reproducible way of collecting aggregated
+statistics about clinical trials directly from the public ClinicalTrials.gov
+API.  The dashboard contained in ``cooperative_rnd_model_interactive.html``
+focuses on counts of late stage trials (phases I-III) for a list of pharma
+companies.  The helper below replicates those numbers based on the actual
+registry data.
+
+Example usage from the command line::
+
+    $ python data_fetch/build_clinical_trials_dataset.py \
+        --sponsor Pfizer --sponsor BIOCAD --max-studies 500 \
+        --out data/clinical_trials_by_sponsor.json
+
+The resulting JSON is structured as follows::
+
+    {
+        "generated_at": "2024-05-01T12:00:00Z",
+        "expr": "Sponsorship filters used in the query",
+        "sponsors": [
+            {
+                "name": "Pfizer",
+                "total_trials": 134,
+                "phase_counts": {"Phase 1": 34, "Phase 2": 51, ...},
+                "status_counts": {"Recruiting": 24, "Completed": 70, ...}
+            },
+            ...
+        ]
+    }
+
+The aggregation makes it easy to align the dashboard inputs with the public
+registries and can be re-run periodically to refresh the data.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, Iterable, List, Sequence
+
+try:  # pragma: no cover - runtime import resolution helper
+    if __package__:
+        from .clinical_trials_api import ClinicalTrialsClient
+    else:  # When executed as ``python data_fetch/build_clinical_trials_dataset.py``
+        from clinical_trials_api import ClinicalTrialsClient  # type: ignore
+except ImportError:  # Fallback to path manipulation when packaged import fails
+    import sys
+
+    from pathlib import Path as _Path
+
+    sys.path.append(str(_Path(__file__).resolve().parent))
+    from clinical_trials_api import ClinicalTrialsClient  # type: ignore
+
+# Fields that we will reuse.  ``Phase`` and ``OverallStatus`` are critical for
+# the R&D modelling.  Additional metadata makes the dataset more useful for
+# debugging and manual inspection.
+FIELDS = [
+    "NCTId",
+    "LeadSponsorName",
+    "CollaboratorName",
+    "Phase",
+    "OverallStatus",
+    "StudyType",
+    "Condition",
+    "EnrollmentCount",
+    "StartDate",
+    "PrimaryCompletionDate",
+    "LastUpdatePostDate",
+]
+
+# Keywords used by the API when a study does not contain a standard phase entry.
+NON_PHASE_VALUES = {
+    "EARLY_PHASE1": "Early Phase 1",
+    "NA": "Not Applicable",
+    "PHASE1_PHASE2": "Phase 1/Phase 2",
+    "PHASE2_PHASE3": "Phase 2/Phase 3",
+}
+
+
+def normalise_phase(value: str) -> Sequence[str]:
+    """Split compound phase labels into canonical buckets.
+
+    The API uses strings such as ``"Phase 1|Phase 2"`` or ``"Phase 1/Phase 2"``
+    to represent studies that span multiple stages.  For the dashboard we are
+    primarily interested in the aggregated counts per (I, II, III).  When a
+    multi-phase entry is detected we increment counters for each individual
+    bucket.  Non-standard values are mapped using :data:`NON_PHASE_VALUES`.
+    """
+
+    value = value.strip()
+    if not value:
+        return ()
+
+    replacements = {
+        "EARLY PHASE 1": "Early Phase 1",
+        "PHASE 1/PHASE 2": "Phase 1/Phase 2",
+        "PHASE 2/PHASE 3": "Phase 2/Phase 3",
+    }
+    value = replacements.get(value.upper(), value)
+    if value.upper() in NON_PHASE_VALUES:
+        return (NON_PHASE_VALUES[value.upper()],)
+
+    separators = ["/", "|", ","]
+    for sep in separators:
+        if sep in value:
+            return tuple(part.strip() for part in value.split(sep) if part.strip())
+    return (value,)
+
+
+def aggregate_trials(studies: Iterable[Dict[str, List[str]]]) -> Dict[str, Counter]:
+    """Aggregate per-phase and per-status statistics for the studies list."""
+
+    phase_counter: Counter[str] = Counter()
+    status_counter: Counter[str] = Counter()
+
+    for study in studies:
+        phase_values = study.get("Phase", [])
+        if phase_values:
+            for label in normalise_phase(phase_values[0]):
+                phase_counter[label] += 1
+
+        status_values = study.get("OverallStatus", [])
+        if status_values:
+            status_counter[status_values[0]] += 1
+
+    return {
+        "phase_counts": phase_counter,
+        "status_counts": status_counter,
+    }
+
+
+def build_dataset_for_sponsor(
+    client: ClinicalTrialsClient,
+    sponsor: str,
+    *,
+    max_studies: int,
+    expr_template: str,
+    batch_size: int,
+) -> Dict[str, object]:
+    """Fetch and aggregate studies for a particular sponsor."""
+
+    expr = expr_template.format(sponsor=sponsor)
+    studies: List[Dict[str, List[str]]] = []
+    for chunk in client.fetch_study_fields(
+        expr=expr,
+        fields=FIELDS,
+        batch_size=batch_size,
+        max_rank=max_studies,
+    ):
+        studies.extend(chunk.studies)
+    aggregated = aggregate_trials(studies)
+
+    return {
+        "name": sponsor,
+        "expr": expr,
+        "total_trials": len(studies),
+        "phase_counts": dict(aggregated["phase_counts"]),
+        "status_counts": dict(aggregated["status_counts"]),
+    }
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--sponsor",
+        action="append",
+        help="Repeatable sponsor name filter (LeadSponsorName).",
+    )
+    parser.add_argument(
+        "--expr",
+        help=(
+            "Custom ClinicalTrials.gov expression. Mutually exclusive with --sponsor."
+            " When provided the query will be executed verbatim."
+        ),
+    )
+    parser.add_argument(
+        "--max-studies",
+        type=int,
+        default=1000,
+        help="Upper bound for the number of studies retrieved per sponsor.",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=200,
+        help="Number of studies requested per API call (max 1000).",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=Path("data/clinical_trials_by_sponsor.json"),
+        help="Output path for the dataset (JSON).",
+    )
+    parser.add_argument(
+        "--expr-template",
+        default='LEADSPONSOR:"{sponsor}"',
+        help="Template used to construct the API expression for each sponsor.",
+    )
+    parser.add_argument(
+        "--indent",
+        type=int,
+        default=2,
+        help="Indentation level for the output JSON file.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    client = ClinicalTrialsClient()
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+
+    dataset: Dict[str, object] = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "fields": FIELDS,
+        "sponsors": [],
+    }
+
+    if args.expr:
+        # Single expression mode – fetch everything matching the expression and
+        # aggregate the results as a single cohort.
+        studies: List[Dict[str, List[str]]] = []
+        for chunk in client.fetch_study_fields(
+            expr=args.expr,
+            fields=FIELDS,
+            batch_size=args.batch_size,
+            max_rank=args.max_studies,
+        ):
+            studies.extend(chunk.studies)
+        aggregated = aggregate_trials(studies)
+        dataset["expr"] = args.expr
+        dataset["total_trials"] = len(studies)
+        dataset["phase_counts"] = dict(aggregated["phase_counts"])
+        dataset["status_counts"] = dict(aggregated["status_counts"])
+    else:
+        sponsors = args.sponsor or [
+            "Pfizer",
+            "BIOCAD",
+            "Generium",
+            "R-Pharm",
+            "Pharmstandard",
+            "Geropharm",
+            "Petrovax",
+            "Valenta",
+            "Nanolek",
+            "ChemRar",
+        ]
+
+        dataset["expr_template"] = args.expr_template
+        for sponsor in sponsors:
+            sponsor_data = build_dataset_for_sponsor(
+                client,
+                sponsor,
+                max_studies=args.max_studies,
+                expr_template=args.expr_template,
+                batch_size=args.batch_size,
+            )
+            dataset["sponsors"].append(sponsor_data)
+
+    with args.out.open("w", encoding="utf-8") as f:
+        json.dump(dataset, f, ensure_ascii=False, indent=args.indent)
+
+    print(f"Dataset written to {args.out}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/data_fetch/clinical_trials_api.py
+++ b/data_fetch/clinical_trials_api.py
@@ -1,0 +1,187 @@
+"""Utilities for interacting with the ClinicalTrials.gov API.
+
+This module exposes thin wrappers above the public REST API provided by
+https://clinicaltrials.gov/.  The functions are intentionally lightweight so
+that they can be reused from notebooks or from other scripts inside the
+project.
+
+The API exposes two main query endpoints:
+
+* ``query/study_fields`` – allows retrieving structured fields for many
+  studies at once and is perfect for building aggregated datasets.
+* ``query/full_studies`` – returns verbose protocol documents.  Fetching the
+  full records is usually unnecessary for dashboard style analytics, therefore
+  the helper below focuses on ``study_fields``.
+
+The implementation respects the public rate limit (10 requests per second as of
+May 2024).  Batching is performed automatically using the ``min_rnk``/``max_rnk``
+parameters provided by the API.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Dict, Iterable, Iterator, List, Optional
+
+import requests
+
+BASE_URL = "https://clinicaltrials.gov/api/query/study_fields"
+# The public documentation suggests keeping requests below 10 per second.
+REQUEST_DELAY = 0.12
+
+
+class ClinicalTrialsAPIError(RuntimeError):
+    """Raised when ClinicalTrials.gov returns an error response."""
+
+
+@dataclass
+class StudyFieldsResponse:
+    """Container holding the raw payload returned by ``study_fields``."""
+
+    studies: List[Dict[str, List[str]]]
+    total_studies: int
+    next_rank: Optional[int]
+
+
+class ClinicalTrialsClient:
+    """Client for the ClinicalTrials.gov ``study_fields`` endpoint.
+
+    Parameters
+    ----------
+    session:
+        Optional :class:`requests.Session` that will be reused between calls.
+    base_url:
+        Alternative URL of the API (kept primarily for testing).
+    request_delay:
+        Artificial pause between requests so that we respect the public rate
+        limit.  The default value (0.12s) keeps us well below 10 requests per
+        second.
+    """
+
+    def __init__(
+        self,
+        session: Optional[requests.Session] = None,
+        *,
+        base_url: str = BASE_URL,
+        request_delay: float = REQUEST_DELAY,
+    ) -> None:
+        self.session = session or requests.Session()
+        self.base_url = base_url.rstrip("/")
+        self.request_delay = request_delay
+
+    def fetch_study_fields(
+        self,
+        *,
+        expr: str,
+        fields: Iterable[str],
+        min_rank: int = 1,
+        max_rank: Optional[int] = None,
+        batch_size: int = 100,
+        fmt: str = "json",
+    ) -> Iterator[StudyFieldsResponse]:
+        """Stream batched ``study_fields`` responses.
+
+        Parameters
+        ----------
+        expr:
+            ClinicalTrials.gov search expression.  Example: ``"COVID-19"`` or
+            ``"AREA[LocationCountry] Russia"``.
+        fields:
+            Sequence of field names to request.
+        min_rank:
+            Starting index (1-based) of the query window.
+        max_rank:
+            Upper bound of the query window.  ``None`` means "fetch everything"
+            for the given expression.
+        batch_size:
+            Number of records returned in a single response.  The API accepts a
+            maximum of 1_000 rows per call, however smaller batches make it
+            easier to stay within the public rate limit.
+        fmt:
+            Response format.  ``json`` is recommended for downstream parsing.
+
+        Yields
+        ------
+        :class:`StudyFieldsResponse`
+            Each item contains the list of studies, the total number of studies
+            matching the expression, and the ``min_rnk`` value to use in the
+            next iteration.  Iteration stops automatically once all studies have
+            been retrieved.
+        """
+
+        current = min_rank
+        while True:
+            if max_rank is not None and current > max_rank:
+                break
+
+            window_max = current + batch_size - 1
+            if max_rank is not None:
+                window_max = min(window_max, max_rank)
+
+            params = {
+                "expr": expr,
+                "fields": ",".join(fields),
+                "min_rnk": current,
+                "max_rnk": window_max,
+                "fmt": fmt,
+            }
+
+            resp = self.session.get(self.base_url, params=params, timeout=30)
+            if resp.status_code != 200:
+                raise ClinicalTrialsAPIError(
+                    f"ClinicalTrials.gov returned HTTP {resp.status_code}: {resp.text[:200]}"
+                )
+
+            payload: Dict[str, Dict[str, object]] = resp.json()
+            data = payload.get("StudyFieldsResponse")
+            if not data or "StudyFields" not in data:
+                raise ClinicalTrialsAPIError(
+                    "Unexpected payload structure received from ClinicalTrials.gov"
+                )
+
+            studies = data.get("StudyFields", [])
+            total_studies = int(data.get("NStudiesFound", 0))
+            fetched = len(studies)
+            next_rank = current + fetched if fetched else None
+
+            yield StudyFieldsResponse(
+                studies=studies,
+                total_studies=total_studies,
+                next_rank=next_rank,
+            )
+
+            if fetched == 0:
+                break
+            if max_rank is not None and next_rank is not None and next_rank > max_rank:
+                break
+            if next_rank is None or next_rank > total_studies:
+                break
+
+            current = next_rank
+            time.sleep(self.request_delay)
+
+    def fetch_all_study_fields(
+        self,
+        *,
+        expr: str,
+        fields: Iterable[str],
+        batch_size: int = 100,
+    ) -> List[Dict[str, List[str]]]:
+        """Convenience helper that materialises the generator into a list."""
+
+        studies: List[Dict[str, List[str]]] = []
+        for chunk in self.fetch_study_fields(
+            expr=expr,
+            fields=fields,
+            batch_size=batch_size,
+        ):
+            studies.extend(chunk.studies)
+        return studies
+
+
+__all__ = [
+    "ClinicalTrialsClient",
+    "ClinicalTrialsAPIError",
+    "StudyFieldsResponse",
+]


### PR DESCRIPTION
## Summary
- add a reusable client for the ClinicalTrials.gov study_fields endpoint
- provide a CLI script that aggregates trials by sponsor and exports JSON datasets for the dashboard

## Testing
- python -m py_compile data_fetch/clinical_trials_api.py data_fetch/build_clinical_trials_dataset.py

------
https://chatgpt.com/codex/tasks/task_e_68dc2b9802e4832a82758615d570c15d