### PR TITLE
Move ClinicalTrials.gov parsers into data package

### DIFF
--- a/data/parsers/__init__.py
+++ b/data/parsers/__init__.py
@@ -1,0 +1,18 @@
+"""Convenience imports for the data parsers package."""
+
+from .base import BaseParser, ParserResult
+from .clinical_trials import (
+    ClinicalTrialsBySponsorParser,
+    ClinicalTrialsExpressionParser,
+    DEFAULT_SPONSORS,
+    FIELDS,
+)
+
+__all__ = [
+    "BaseParser",
+    "ParserResult",
+    "ClinicalTrialsBySponsorParser",
+    "ClinicalTrialsExpressionParser",
+    "DEFAULT_SPONSORS",
+    "FIELDS",
+]

--- a/data/parsers/clinical_trials.py
+++ b/data/parsers/clinical_trials.py
@@ -1,0 +1,213 @@
+"""High level parsers for ClinicalTrials.gov datasets."""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Dict, Iterable, Iterator, List, Sequence
+
+from .base import BaseParser
+from .clinical_trials_api import ClinicalTrialsClient
+
+# Fields that we will reuse. ``Phase`` and ``OverallStatus`` are critical for
+# the R&D modelling. Additional metadata makes the dataset more useful for
+# debugging and manual inspection.
+FIELDS: Sequence[str] = (
+    "NCTId",
+    "LeadSponsorName",
+    "CollaboratorName",
+    "Phase",
+    "OverallStatus",
+    "StudyType",
+    "Condition",
+    "EnrollmentCount",
+    "StartDate",
+    "PrimaryCompletionDate",
+    "LastUpdatePostDate",
+)
+
+DEFAULT_SPONSORS: Sequence[str] = (
+    "Pfizer",
+    "BIOCAD",
+    "Generium",
+    "R-Pharm",
+    "Pharmstandard",
+    "Geropharm",
+    "Petrovax",
+    "Valenta",
+    "Nanolek",
+    "ChemRar",
+)
+
+# Keywords used by the API when a study does not contain a standard phase entry.
+NON_PHASE_VALUES = {
+    "EARLY_PHASE1": "Early Phase 1",
+    "NA": "Not Applicable",
+    "PHASE1_PHASE2": "Phase 1/Phase 2",
+    "PHASE2_PHASE3": "Phase 2/Phase 3",
+}
+
+
+def normalise_phase(value: str) -> Sequence[str]:
+    """Split compound phase labels into canonical buckets."""
+
+    value = value.strip()
+    if not value:
+        return ()
+
+    replacements = {
+        "EARLY PHASE 1": "Early Phase 1",
+        "PHASE 1/PHASE 2": "Phase 1/Phase 2",
+        "PHASE 2/PHASE 3": "Phase 2/Phase 3",
+    }
+    value = replacements.get(value.upper(), value)
+    if value.upper() in NON_PHASE_VALUES:
+        return (NON_PHASE_VALUES[value.upper()],)
+
+    separators = ["/", "|", ","]
+    for sep in separators:
+        if sep in value:
+            return tuple(part.strip() for part in value.split(sep) if part.strip())
+    return (value,)
+
+
+def aggregate_trials(studies: Iterable[Dict[str, List[str]]]) -> Dict[str, Counter[str]]:
+    """Aggregate per-phase and per-status statistics for the studies list."""
+
+    phase_counter: Counter[str] = Counter()
+    status_counter: Counter[str] = Counter()
+
+    for study in studies:
+        phase_values = study.get("Phase", [])
+        if phase_values:
+            for label in normalise_phase(phase_values[0]):
+                phase_counter[label] += 1
+
+        status_values = study.get("OverallStatus", [])
+        if status_values:
+            status_counter[status_values[0]] += 1
+
+    return {
+        "phase_counts": phase_counter,
+        "status_counts": status_counter,
+    }
+
+
+class _ClinicalTrialsBaseParser(BaseParser):
+    """Common configuration shared by ClinicalTrials.gov parsers."""
+
+    def __init__(
+        self,
+        *,
+        client: ClinicalTrialsClient | None = None,
+        fields: Sequence[str] = FIELDS,
+        batch_size: int = 200,
+        max_studies: int | None = 1000,
+    ) -> None:
+        self.client = client or ClinicalTrialsClient()
+        self.fields = tuple(fields)
+        self.batch_size = batch_size
+        self.max_studies = max_studies
+
+    def _collect_studies(self, expr: str) -> List[Dict[str, List[str]]]:
+        """Fetch study records for the provided expression."""
+
+        studies: List[Dict[str, List[str]]] = []
+        fetch_kwargs = {}
+        if self.max_studies is not None:
+            fetch_kwargs["max_rank"] = self.max_studies
+
+        for chunk in self.client.fetch_study_fields(
+            expr=expr,
+            fields=self.fields,
+            batch_size=self.batch_size,
+            **fetch_kwargs,
+        ):
+            studies.extend(chunk.studies)
+        return studies
+
+    @staticmethod
+    def _format_aggregated(
+        *,
+        expr: str,
+        studies: List[Dict[str, List[str]]],
+    ) -> Dict[str, object]:
+        aggregated = aggregate_trials(studies)
+        return {
+            "expr": expr,
+            "total_trials": len(studies),
+            "phase_counts": dict(aggregated["phase_counts"]),
+            "status_counts": dict(aggregated["status_counts"]),
+        }
+
+
+class ClinicalTrialsBySponsorParser(_ClinicalTrialsBaseParser):
+    """Parser that aggregates trial statistics per sponsor."""
+
+    source = "clinical_trials_by_sponsor"
+
+    def __init__(
+        self,
+        sponsors: Sequence[str] | None = None,
+        *,
+        expr_template: str = 'LEADSPONSOR:"{sponsor}"',
+        client: ClinicalTrialsClient | None = None,
+        fields: Sequence[str] = FIELDS,
+        batch_size: int = 200,
+        max_studies: int | None = 1000,
+    ) -> None:
+        super().__init__(
+            client=client,
+            fields=fields,
+            batch_size=batch_size,
+            max_studies=max_studies,
+        )
+        self.expr_template = expr_template
+        self.sponsors = tuple(sponsors or DEFAULT_SPONSORS)
+
+    def fetch(self) -> Iterator[Dict[str, object]]:
+        for sponsor in self.sponsors:
+            expr = self.expr_template.format(sponsor=sponsor)
+            studies = self._collect_studies(expr)
+            payload = self._format_aggregated(expr=expr, studies=studies)
+            payload["name"] = sponsor
+            yield payload
+
+
+class ClinicalTrialsExpressionParser(_ClinicalTrialsBaseParser):
+    """Parser that aggregates statistics for an arbitrary expression."""
+
+    source = "clinical_trials_expression"
+
+    def __init__(
+        self,
+        expr: str,
+        *,
+        client: ClinicalTrialsClient | None = None,
+        fields: Sequence[str] = FIELDS,
+        batch_size: int = 200,
+        max_studies: int | None = 1000,
+    ) -> None:
+        if not expr:
+            raise ValueError("ClinicalTrialsExpressionParser requires a non-empty expression")
+
+        super().__init__(
+            client=client,
+            fields=fields,
+            batch_size=batch_size,
+            max_studies=max_studies,
+        )
+        self.expr = expr
+
+    def fetch(self) -> Iterator[Dict[str, object]]:
+        studies = self._collect_studies(self.expr)
+        yield self._format_aggregated(expr=self.expr, studies=studies)
+
+
+__all__ = [
+    "ClinicalTrialsBySponsorParser",
+    "ClinicalTrialsExpressionParser",
+    "DEFAULT_SPONSORS",
+    "FIELDS",
+    "aggregate_trials",
+    "normalise_phase",
+]

--- a/data/parsers/clinical_trials_api.py
+++ b/data/parsers/clinical_trials_api.py
@@ -80,35 +80,7 @@ class ClinicalTrialsClient:
         batch_size: int = 100,
         fmt: str = "json",
     ) -> Iterator[StudyFieldsResponse]:
-        """Stream batched ``study_fields`` responses.
-
-        Parameters
-        ----------
-        expr:
-            ClinicalTrials.gov search expression.  Example: ``"COVID-19"`` or
-            ``"AREA[LocationCountry] Russia"``.
-        fields:
-            Sequence of field names to request.
-        min_rank:
-            Starting index (1-based) of the query window.
-        max_rank:
-            Upper bound of the query window.  ``None`` means "fetch everything"
-            for the given expression.
-        batch_size:
-            Number of records returned in a single response.  The API accepts a
-            maximum of 1_000 rows per call, however smaller batches make it
-            easier to stay within the public rate limit.
-        fmt:
-            Response format.  ``json`` is recommended for downstream parsing.
-
-        Yields
-        ------
-        :class:`StudyFieldsResponse`
-            Each item contains the list of studies, the total number of studies
-            matching the expression, and the ``min_rnk`` value to use in the
-            next iteration.  Iteration stops automatically once all studies have
-            been retrieved.
-        """
+        """Stream batched ``study_fields`` responses."""
 
         current = min_rank
         while True:

--- a/data_fetch/build_clinical_trials_dataset.py
+++ b/data_fetch/build_clinical_trials_dataset.py
@@ -37,130 +37,23 @@ from __future__ import annotations
 
 import argparse
 import json
-from collections import Counter
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Dict, Iterable, List, Sequence
-
-try:  # pragma: no cover - runtime import resolution helper
-    if __package__:
-        from .clinical_trials_api import ClinicalTrialsClient
-    else:  # When executed as ``python data_fetch/build_clinical_trials_dataset.py``
-        from clinical_trials_api import ClinicalTrialsClient  # type: ignore
-except ImportError:  # Fallback to path manipulation when packaged import fails
-    import sys
-
-    from pathlib import Path as _Path
-
-    sys.path.append(str(_Path(__file__).resolve().parent))
-    from clinical_trials_api import ClinicalTrialsClient  # type: ignore
-
-# Fields that we will reuse.  ``Phase`` and ``OverallStatus`` are critical for
-# the R&D modelling.  Additional metadata makes the dataset more useful for
-# debugging and manual inspection.
-FIELDS = [
-    "NCTId",
-    "LeadSponsorName",
-    "CollaboratorName",
-    "Phase",
-    "OverallStatus",
-    "StudyType",
-    "Condition",
-    "EnrollmentCount",
-    "StartDate",
-    "PrimaryCompletionDate",
-    "LastUpdatePostDate",
-]
-
-# Keywords used by the API when a study does not contain a standard phase entry.
-NON_PHASE_VALUES = {
-    "EARLY_PHASE1": "Early Phase 1",
-    "NA": "Not Applicable",
-    "PHASE1_PHASE2": "Phase 1/Phase 2",
-    "PHASE2_PHASE3": "Phase 2/Phase 3",
-}
+import sys
+from typing import Dict, Sequence
 
 
-def normalise_phase(value: str) -> Sequence[str]:
-    """Split compound phase labels into canonical buckets.
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
 
-    The API uses strings such as ``"Phase 1|Phase 2"`` or ``"Phase 1/Phase 2"``
-    to represent studies that span multiple stages.  For the dashboard we are
-    primarily interested in the aggregated counts per (I, II, III).  When a
-    multi-phase entry is detected we increment counters for each individual
-    bucket.  Non-standard values are mapped using :data:`NON_PHASE_VALUES`.
-    """
-
-    value = value.strip()
-    if not value:
-        return ()
-
-    replacements = {
-        "EARLY PHASE 1": "Early Phase 1",
-        "PHASE 1/PHASE 2": "Phase 1/Phase 2",
-        "PHASE 2/PHASE 3": "Phase 2/Phase 3",
-    }
-    value = replacements.get(value.upper(), value)
-    if value.upper() in NON_PHASE_VALUES:
-        return (NON_PHASE_VALUES[value.upper()],)
-
-    separators = ["/", "|", ","]
-    for sep in separators:
-        if sep in value:
-            return tuple(part.strip() for part in value.split(sep) if part.strip())
-    return (value,)
-
-
-def aggregate_trials(studies: Iterable[Dict[str, List[str]]]) -> Dict[str, Counter]:
-    """Aggregate per-phase and per-status statistics for the studies list."""
-
-    phase_counter: Counter[str] = Counter()
-    status_counter: Counter[str] = Counter()
-
-    for study in studies:
-        phase_values = study.get("Phase", [])
-        if phase_values:
-            for label in normalise_phase(phase_values[0]):
-                phase_counter[label] += 1
-
-        status_values = study.get("OverallStatus", [])
-        if status_values:
-            status_counter[status_values[0]] += 1
-
-    return {
-        "phase_counts": phase_counter,
-        "status_counts": status_counter,
-    }
-
-
-def build_dataset_for_sponsor(
-    client: ClinicalTrialsClient,
-    sponsor: str,
-    *,
-    max_studies: int,
-    expr_template: str,
-    batch_size: int,
-) -> Dict[str, object]:
-    """Fetch and aggregate studies for a particular sponsor."""
-
-    expr = expr_template.format(sponsor=sponsor)
-    studies: List[Dict[str, List[str]]] = []
-    for chunk in client.fetch_study_fields(
-        expr=expr,
-        fields=FIELDS,
-        batch_size=batch_size,
-        max_rank=max_studies,
-    ):
-        studies.extend(chunk.studies)
-    aggregated = aggregate_trials(studies)
-
-    return {
-        "name": sponsor,
-        "expr": expr,
-        "total_trials": len(studies),
-        "phase_counts": dict(aggregated["phase_counts"]),
-        "status_counts": dict(aggregated["status_counts"]),
-    }
+from data.parsers.clinical_trials import (
+    ClinicalTrialsBySponsorParser,
+    ClinicalTrialsExpressionParser,
+    DEFAULT_SPONSORS,
+    FIELDS,
+)
+from data.parsers.clinical_trials_api import ClinicalTrialsClient
 
 
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
@@ -217,50 +110,32 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     dataset: Dict[str, object] = {
         "generated_at": datetime.now(timezone.utc).isoformat(),
-        "fields": FIELDS,
+        "fields": list(FIELDS),
         "sponsors": [],
     }
 
     if args.expr:
-        # Single expression mode – fetch everything matching the expression and
-        # aggregate the results as a single cohort.
-        studies: List[Dict[str, List[str]]] = []
-        for chunk in client.fetch_study_fields(
+        parser = ClinicalTrialsExpressionParser(
             expr=args.expr,
+            client=client,
             fields=FIELDS,
             batch_size=args.batch_size,
-            max_rank=args.max_studies,
-        ):
-            studies.extend(chunk.studies)
-        aggregated = aggregate_trials(studies)
-        dataset["expr"] = args.expr
-        dataset["total_trials"] = len(studies)
-        dataset["phase_counts"] = dict(aggregated["phase_counts"])
-        dataset["status_counts"] = dict(aggregated["status_counts"])
+            max_studies=args.max_studies,
+        )
+        record = parser.parse().payload["records"][0]
+        dataset.update(record)
     else:
-        sponsors = args.sponsor or [
-            "Pfizer",
-            "BIOCAD",
-            "Generium",
-            "R-Pharm",
-            "Pharmstandard",
-            "Geropharm",
-            "Petrovax",
-            "Valenta",
-            "Nanolek",
-            "ChemRar",
-        ]
-
+        sponsors = args.sponsor or list(DEFAULT_SPONSORS)
+        parser = ClinicalTrialsBySponsorParser(
+            sponsors=sponsors,
+            expr_template=args.expr_template,
+            client=client,
+            fields=FIELDS,
+            batch_size=args.batch_size,
+            max_studies=args.max_studies,
+        )
         dataset["expr_template"] = args.expr_template
-        for sponsor in sponsors:
-            sponsor_data = build_dataset_for_sponsor(
-                client,
-                sponsor,
-                max_studies=args.max_studies,
-                expr_template=args.expr_template,
-                batch_size=args.batch_size,
-            )
-            dataset["sponsors"].append(sponsor_data)
+        dataset["sponsors"] = parser.parse().payload["records"]
 
     with args.out.open("w", encoding="utf-8") as f:
         json.dump(dataset, f, ensure_ascii=False, indent=args.indent)


### PR DESCRIPTION
## Summary
- add reusable ClinicalTrials.gov parser classes under data/parsers following the BaseParser contract
- relocate the API client alongside the parsers and expose convenient imports from the package
- update the dataset CLI script to consume the new parsers and shared configuration

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc2e627f58832aa792351585e21751