### PR TITLE
Add launch guide notebook

### DIFF
--- a/launch_guide.ipynb
+++ b/launch_guide.ipynb
@@ -1,0 +1,163 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Интерактивный запуск проекта\n",
+    "\n",
+    "Этот ноутбук помогает быстро просмотреть статическую HTML-версию интерфейса и запустить локальную версию Dash-приложения из `app.py`. Пошаговые инструкции включены в отдельных разделах."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Подготовка окружения\n",
+    "\n",
+    "1. Убедитесь, что у вас установлен Python 3.10 или новее.\n",
+    "2. Создайте и активируйте виртуальное окружение:\n",
+    "```\n",
+    "python -m venv .venv\n",
+    "source .venv/bin/activate  # Windows: .venv\\\\Scripts\\\\activate\n",
+    "```\n",
+    "3. Установите зависимости проекта:\n",
+    "```\n",
+    "pip install -r requirements.txt\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Просмотр статической HTML-версии\n",
+    "\n",
+    "Выполните ячейку ниже, чтобы отобразить сохранённую HTML-версию дашборда (`cooperative_rnd_model_interactive.html`).\n",
+    "\n",
+    "> **Совет:** если в браузере Jupyter отображение не открывается во встроенном фрейме, скачайте файл напрямую и откройте его в отдельной вкладке."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "from IPython.display import IFrame, display\n",
+    "\n",
+    "html_path = Path('cooperative_rnd_model_interactive.html').resolve()\n",
+    "if html_path.exists():\n",
+    "    display(IFrame(src=html_path.as_uri(), width='100%', height=600))\n",
+    "else:\n",
+    "    raise FileNotFoundError(f'HTML-файл не найден: {html_path}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Запуск Dash-приложения (`app.py`)\n",
+    "\n",
+    "1. Убедитесь, что зависимости установлены (см. раздел выше).\n",
+    "2. Выполните следующую ячейку, чтобы запустить сервер прямо из ноутбука. После запуска откройте адрес [http://127.0.0.1:8050/](http://127.0.0.1:8050/) в браузере.\n",
+    "3. После завершения работы не забудьте остановить сервер, выполнив ячейку **\"Остановка сервера\"** ниже.\n",
+    "\n",
+    "> **Примечание:** ячейка запуска проверяет, не запущен ли сервер ранее, чтобы избежать дубликатов процессов."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pathlib\n",
+    "import subprocess\n",
+    "import sys\n",
+    "\n",
+    "if 'app_process' in globals() and app_process.poll() is None:\n",
+    "    print('Сервер уже запущен на http://127.0.0.1:8050/.')\n",
+    "else:\n",
+    "    project_root = pathlib.Path.cwd()\n",
+    "    app_process = subprocess.Popen([sys.executable, '-m', 'app.app'], cwd=project_root)\n",
+    "    print('Сервер запущен на http://127.0.0.1:8050/. Откройте ссылку в браузере.')\n",
+    "    print('Чтобы остановить сервер, выполните ячейку ниже.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Остановка сервера\n",
+    "\n",
+    "После просмотра приложения выполните ячейку ниже, чтобы корректно завершить процесс Dash. Это освободит порт и предотвратит \"залипание\" фоновых процессов."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if 'app_process' in globals():\n",
+    "    if app_process.poll() is None:\n",
+    "        app_process.terminate()\n",
+    "        app_process.wait()\n",
+    "        print('Сервер остановлен.')\n",
+    "    else:\n",
+    "        print('Процесс сервера уже завершён.')\n",
+    "else:\n",
+    "    print('Переменная app_process не определена: сервер ещё не запускался в этой сессии.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Проверка работы парсеров\n",
+    "\n",
+    "Папка `data/parsers/` содержит базовые классы для будущих парсеров внешних источников данных. Ячейка ниже создаёт демонстрационный парсер, наследующийся от `BaseParser`, и показывает, что метод `parse()` возвращает нормализованный результат.\n",
+    "\n",
+    "> **Как проверить свои парсеры:** замените реализацию `DemoParser.fetch()` на свою и убедитесь, что словарь `payload` содержит ожидаемые записи. При необходимости добавьте автоматические тесты в каталог `tests/`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from data.parsers.base import BaseParser\n",
+    "\n",
+    "class DemoParser(BaseParser):\n",
+    "    source = 'demo-source'\n",
+    "\n",
+    "    def fetch(self):\n",
+    "        yield {'id': 1, 'title': 'First record', 'value': 42}\n",
+    "        yield {'id': 2, 'title': 'Second record', 'value': 1337}\n",
+    "\n",
+    "parser = DemoParser()\n",
+    "result = parser.parse()\n",
+    "print(result)\n",
+    "print('\nПолученные записи:')\n",
+    "for record in result.payload['records']:\n",
+    "    print('-', record)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a launch guide notebook with step-by-step instructions for viewing the saved HTML dashboard
- include code cells to start and stop the Dash app server from Jupyter
- provide a demo parser example to verify parser workflows

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc359951a0832abaa1091c81b89d14