### PR TITLE
Add clinical trial harvesting CLI pipeline

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ dash>=2.14
 plotly>=5.18
 pandas>=2.0
 pytest>=7.4
+requests>=2.31
+python-dateutil>=2.8

--- a/tests/fixtures/ctg_study.json
+++ b/tests/fixtures/ctg_study.json
@@ -1,0 +1,50 @@
+{
+  "ProtocolSection": {
+    "IdentificationModule": {
+      "NCTId": "NCT01234567",
+      "BriefTitle": "Example oncology study",
+      "OfficialTitle": "Phase 2 Study of Example Drug",
+      "OrgStudyIdInfo": {"OrgStudyId": "ABC-123"},
+      "SecondaryIdList": {"SecondaryId": ["EUCTR2019-012345-67", "ISRCTN12345678"]}
+    },
+    "StatusModule": {
+      "OverallStatus": "Recruiting",
+      "StartDateStruct": {"StartDate": "January 2023"},
+      "PrimaryCompletionDateStruct": {"PrimaryCompletionDate": "March 2024"},
+      "CompletionDateStruct": {"CompletionDate": "June 2024"},
+      "LastUpdatePostDateStruct": {"LastUpdatePostDate": "2024-02-01"}
+    },
+    "DesignModule": {
+      "PhaseList": {"Phase": ["Phase 2"]},
+      "StudyType": "Interventional",
+      "EnrollmentInfo": {"EnrollmentCount": "120"}
+    },
+    "SponsorCollaboratorsModule": {
+      "LeadSponsor": {"LeadSponsorName": "BioPharma"},
+      "CollaboratorList": {"Collaborator": [{"CollaboratorName": "CoLab One"}]}
+    },
+    "ContactsLocationsModule": {
+      "LocationList": {
+        "Location": [
+          {"LocationCountry": "United States"},
+          {"LocationCountry": "Canada"}
+        ]
+      }
+    },
+    "LocationCountriesModule": {
+      "LocationCountry": ["United States", "Canada"]
+    },
+    "ConditionsModule": {
+      "ConditionList": {"Condition": ["Oncology Condition"]}
+    },
+    "ArmsInterventionsModule": {
+      "InterventionList": {
+        "Intervention": [
+          {"InterventionName": "Drug A"},
+          {"InterventionName": "Drug B"}
+        ]
+      }
+    }
+  },
+  "StudyType": "Interventional"
+}

--- a/tests/test_trials_harvester.py
+++ b/tests/test_trials_harvester.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+from trials_harvester.normalization.clinicaltrials_gov import normalize_study
+from trials_harvester.normalization.utils import normalize_countries, normalize_phase
+from trials_harvester.sources.base import FetchConfig
+from trials_harvester.sources.clinicaltrials_gov import ClinicalTrialsGovFetcher
+
+
+FIXTURE_DIR = Path(__file__).resolve().parent / "fixtures"
+
+
+def load_fixture(name: str) -> dict:
+    with (FIXTURE_DIR / name).open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def test_normalize_clinicaltrials_study() -> None:
+    study = load_fixture("ctg_study.json")
+    trial = normalize_study(study)
+
+    assert trial.source == "clinicaltrials_gov"
+    assert trial.source_id == "NCT01234567"
+    assert trial.public_title == "Example oncology study"
+    assert trial.scientific_title == "Phase 2 Study of Example Drug"
+    assert trial.sponsor_primary == "BioPharma"
+    assert trial.sponsors_all == ["BioPharma", "CoLab One"]
+    assert trial.phase == "II"
+    assert trial.overall_status == "recruiting"
+    assert trial.study_type == "interventional"
+    assert trial.enrollment == 120
+    assert trial.centers_count == 2
+    assert trial.countries == ["US", "CA"]
+    assert trial.conditions == ["Oncology Condition"]
+    assert trial.interventions == ["Drug A", "Drug B"]
+    assert trial.start_date == "2023-01-01"
+    assert trial.primary_completion_date == "2024-03-01"
+    assert trial.completion_date == "2024-06-01"
+    assert trial.nct_id == "NCT01234567"
+    assert trial.eudract_number == "EUCTR2019-012345-67"
+    assert trial.isrctn == "ISRCTN12345678"
+    assert trial.protocol_id == "ABC-123"
+    assert trial.last_updated_date == "2024-02-01"
+    assert trial.language == "en"
+    assert isinstance(trial.raw_payload, dict)
+
+
+def test_normalize_phase_variants() -> None:
+    assert normalize_phase(["Phase 1/Phase 2"]) == "I/II"
+    assert normalize_phase(["Phase 2", "Phase 3"]) == "II/III"
+    assert normalize_phase(["Not Applicable"]) == "NA"
+
+
+def test_normalize_countries_handles_iso_codes() -> None:
+    assert normalize_countries(["United States", "ca", "Unknown"])[:2] == ["US", "CA"]
+
+
+def test_clinicaltrials_fetcher_paginates(monkeypatch) -> None:
+    config = FetchConfig(query="oncology", batch_size=2, max_records=3)
+    fetcher = ClinicalTrialsGovFetcher(config)
+
+    responses = [
+        {
+            "FullStudiesResponse": {
+                "FullStudies": [
+                    {"Study": load_fixture("ctg_study.json")},
+                ]
+            }
+        },
+        {"FullStudiesResponse": {"FullStudies": []}},
+    ]
+    call_index = {"value": 0}
+
+    def fake_request(self, params):  # pragma: no cover - monkeypatched
+        idx = call_index["value"]
+        call_index["value"] += 1
+        return responses[min(idx, len(responses) - 1)]
+
+    monkeypatch.setattr(ClinicalTrialsGovFetcher, "_perform_request", fake_request, raising=False)
+    monkeypatch.setattr("trials_harvester.sources.clinicaltrials_gov.time.sleep", lambda _: None)
+
+    results = list(fetcher.fetch())
+    assert len(results) == 1
+    assert results[0]["StudyType"] == "Interventional"
+
+

--- a/trials_harvester/__init__.py
+++ b/trials_harvester/__init__.py
@@ -1,0 +1,7 @@
+"""Command line utilities for harvesting clinical trial registries."""
+
+from __future__ import annotations
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/trials_harvester/__main__.py
+++ b/trials_harvester/__main__.py
@@ -1,0 +1,9 @@
+"""Module entry point for :mod:`trials_harvester`."""
+
+from __future__ import annotations
+
+from .cli import main
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/trials_harvester/cli.py
+++ b/trials_harvester/cli.py
@@ -1,0 +1,159 @@
+"""Command line interface for :mod:`trials_harvester`."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Sequence
+
+from . import __version__
+from .commands.dedupe import run as run_dedupe
+from .commands.fetch import run as run_fetch
+from .commands.normalize import run as run_normalize
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="trials_harvester",
+        description=(
+            "Utilities for downloading, normalising and deduplicating clinical "
+            "trial registries."
+        ),
+    )
+    parser.add_argument(
+        "--version", action="version", version=f"trials_harvester {__version__}"
+    )
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    fetch_parser = subparsers.add_parser(
+        "fetch",
+        help="Download raw data from a registry and persist it as JSON Lines.",
+    )
+    fetch_parser.add_argument(
+        "--source",
+        required=True,
+        help="Registry identifier (e.g. clinicaltrials).",
+    )
+    fetch_parser.add_argument(
+        "--query",
+        help="Free-form query expression understood by the registry.",
+    )
+    fetch_parser.add_argument(
+        "--since",
+        help="Optional lower bound for the last update date (YYYY-MM-DD).",
+    )
+    fetch_parser.add_argument(
+        "--until",
+        help="Optional upper bound for the last update date (YYYY-MM-DD).",
+    )
+    fetch_parser.add_argument(
+        "--country",
+        action="append",
+        help="Country filter (repeatable).",
+    )
+    fetch_parser.add_argument(
+        "--sponsor",
+        action="append",
+        help="Sponsor filter (repeatable).",
+    )
+    fetch_parser.add_argument(
+        "--phase",
+        help="Phase filter expressed as comma separated values (e.g. I,II,III).",
+    )
+    fetch_parser.add_argument(
+        "--status",
+        help="Recruitment status filter expressed as comma separated values.",
+    )
+    fetch_parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=100,
+        help="Number of records to request per API call (if supported).",
+    )
+    fetch_parser.add_argument(
+        "--max-records",
+        type=int,
+        help="Maximum number of records to retrieve.",
+    )
+    fetch_parser.add_argument(
+        "--out",
+        required=True,
+        type=Path,
+        help="Destination file for the raw JSON Lines payload.",
+    )
+
+    normalize_parser = subparsers.add_parser(
+        "normalize",
+        help="Convert raw payloads into the unified Trial schema.",
+    )
+    normalize_parser.add_argument(
+        "--in",
+        dest="inputs",
+        nargs="+",
+        required=True,
+        help="Input files containing raw payloads (JSON or JSONL).",
+    )
+    normalize_parser.add_argument(
+        "--out",
+        required=True,
+        type=Path,
+        help="Destination file for the normalised dataset (CSV or Parquet).",
+    )
+
+    dedupe_parser = subparsers.add_parser(
+        "dedupe",
+        help="Deduplicate normalised tables using strict and fuzzy strategies.",
+    )
+    dedupe_parser.add_argument(
+        "--in",
+        dest="input_path",
+        required=True,
+        type=Path,
+        help="Input CSV/Parquet file produced by the normaliser.",
+    )
+    dedupe_parser.add_argument(
+        "--by",
+        required=True,
+        help="Comma separated list of columns used for strict deduplication.",
+    )
+    dedupe_parser.add_argument(
+        "--out",
+        required=True,
+        type=Path,
+        help="Destination path for the deduplicated dataset.",
+    )
+    dedupe_parser.add_argument(
+        "--fuzzy-title",
+        action="store_true",
+        help=(
+            "Enable fuzzy matching on public titles to collapse additional "
+            "duplicates."
+        ),
+    )
+    dedupe_parser.add_argument(
+        "--fuzzy-threshold",
+        type=int,
+        default=92,
+        help="Similarity threshold (0-100) for fuzzy title matching.",
+    )
+
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "fetch":
+        run_fetch(args)
+    elif args.command == "normalize":
+        run_normalize(args)
+    elif args.command == "dedupe":
+        run_dedupe(args)
+    else:  # pragma: no cover - safeguard
+        parser.error(f"Unknown command: {args.command}")
+    return 0
+
+
+__all__ = ["build_parser", "main"]

--- a/trials_harvester/commands/dedupe.py
+++ b/trials_harvester/commands/dedupe.py
@@ -1,0 +1,71 @@
+"""Implementation of the :code:`dedupe` CLI command."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Sequence
+
+import pandas as pd
+from difflib import SequenceMatcher
+
+from ..io import read_table, write_dataframe
+
+
+def _fuzzy_score(left: str, right: str) -> int:
+    if not left and not right:
+        return 100
+    return int(SequenceMatcher(None, left, right).ratio() * 100)
+
+
+def _fuzzy_collapse(df: pd.DataFrame, threshold: int) -> pd.DataFrame:
+    if "public_title" not in df.columns:
+        return df
+
+    dropped: set[int] = set()
+    kept: list[tuple[int, pd.Series]] = []
+
+    for idx, row in df.iterrows():
+        if idx in dropped:
+            continue
+        title = row.get("public_title") or ""
+        sponsor = row.get("sponsor_primary") or ""
+        start_date = row.get("start_date") or ""
+        start_year = start_date[:4]
+
+        matched = False
+        for keep_idx, keep_row in kept:
+            if sponsor and sponsor == keep_row.get("sponsor_primary"):
+                other_title = keep_row.get("public_title") or ""
+                other_year = (keep_row.get("start_date") or "")[:4]
+                score = _fuzzy_score(title, other_title)
+                if score >= threshold and (not start_year or start_year == other_year):
+                    dropped.add(idx)
+                    matched = True
+                    break
+        if not matched:
+            kept.append((idx, row))
+
+    if not dropped:
+        return df
+    return df.drop(index=list(dropped))
+
+
+def run(args: Sequence[str] | object) -> None:
+    input_path: Path = args.input_path
+    output_path: Path = args.out
+    columns = [col.strip() for col in getattr(args, "by").split(",") if col.strip()]
+    if not columns:
+        raise ValueError("--by must contain at least one column")
+
+    df = read_table(input_path)
+    initial = len(df)
+    df = df.drop_duplicates(subset=columns, keep="first")
+
+    if getattr(args, "fuzzy_title"):
+        df = _fuzzy_collapse(df, threshold=int(getattr(args, "fuzzy_threshold")))
+
+    write_dataframe(df, output_path)
+    print(f"Deduplicated {initial} -> {len(df)} records written to {output_path}")
+
+
+__all__ = ["run"]

--- a/trials_harvester/commands/fetch.py
+++ b/trials_harvester/commands/fetch.py
@@ -1,0 +1,62 @@
+"""Implementation of the :code:`fetch` CLI command."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Sequence
+
+try:
+    from tqdm import tqdm
+except ImportError:  # pragma: no cover - optional dependency
+    def tqdm(iterable, **kwargs):
+        return iterable
+
+from ..sources import create_fetcher
+
+
+def _split_csv(value: str | None) -> list[str] | None:
+    if value is None:
+        return None
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def run(args: Sequence[str] | object) -> None:
+    """Execute the fetch command using the parsed ``argparse`` namespace."""
+
+    output: Path = args.out
+    output.parent.mkdir(parents=True, exist_ok=True)
+
+    phase_filters = _split_csv(getattr(args, "phase", None))
+    status_filters = _split_csv(getattr(args, "status", None))
+
+    fetcher = create_fetcher(
+        source=getattr(args, "source"),
+        query=getattr(args, "query", None),
+        since=getattr(args, "since", None),
+        until=getattr(args, "until", None),
+        countries=getattr(args, "country", None),
+        sponsors=getattr(args, "sponsor", None),
+        phases=phase_filters,
+        statuses=status_filters,
+        batch_size=getattr(args, "batch_size", 100),
+        max_records=getattr(args, "max_records", None),
+    )
+
+    count = 0
+    with output.open("w", encoding="utf-8") as fh:
+        for record in tqdm(fetcher.fetch(), desc=f"Fetching {fetcher.source}"):
+            payload = {
+                "source": fetcher.source,
+                "fetched_at": datetime.now(timezone.utc).isoformat(),
+                "record": record,
+            }
+            fh.write(json.dumps(payload, ensure_ascii=False))
+            fh.write("\n")
+            count += 1
+
+    print(f"Fetched {count} records from {fetcher.source} -> {output}")
+
+
+__all__ = ["run"]

--- a/trials_harvester/commands/normalize.py
+++ b/trials_harvester/commands/normalize.py
@@ -1,0 +1,53 @@
+"""Implementation of the :code:`normalize` CLI command."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Sequence
+
+import pandas as pd
+
+from ..io import iter_raw_payloads, write_dataframe
+from ..normalization import Trial, normalize_record
+
+
+def run(args: Sequence[str] | object) -> None:
+    output: Path = args.out
+    inputs = getattr(args, "inputs")
+    records: list[dict] = []
+    errors = 0
+
+    for payload in iter_raw_payloads(inputs):
+        source = payload.get("source") if isinstance(payload, dict) else None
+        record = payload.get("record") if isinstance(payload, dict) else None
+        if isinstance(record, dict) and isinstance(source, str):
+            raw = record
+            raw_source = source
+        elif isinstance(payload, dict):
+            raw = payload
+            raw_source = source or payload.get("source")
+        else:
+            continue
+
+        if not isinstance(raw_source, str):
+            raise ValueError("Input payload is missing the 'source' key")
+
+        try:
+            trial: Trial = normalize_record(raw_source, raw)
+        except ValueError as exc:
+            errors += 1
+            print(f"Skipping record due to error: {exc}")
+            continue
+        records.append(trial.to_dict())
+
+    df = pd.DataFrame(records)
+    write_dataframe(df, output)
+
+    print(
+        f"Normalised {len(records)} records from {len(inputs)} files -> {output}"
+    )
+    if errors:
+        print(f"Encountered {errors} records with validation errors")
+
+
+__all__ = ["run"]

--- a/trials_harvester/io.py
+++ b/trials_harvester/io.py
@@ -1,0 +1,72 @@
+"""Utility helpers for reading and writing datasets."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Iterable, Iterator
+
+import pandas as pd
+
+
+def iter_raw_payloads(paths: Iterable[str | Path]) -> Iterator[Dict[str, object]]:
+    for path_like in paths:
+        path = Path(path_like)
+        if not path.exists():
+            raise FileNotFoundError(path)
+        suffix = path.suffix.lower()
+        if suffix == ".jsonl":
+            with path.open("r", encoding="utf-8") as fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    yield json.loads(line)
+        elif suffix == ".json":
+            with path.open("r", encoding="utf-8") as fh:
+                payload = json.load(fh)
+            if isinstance(payload, list):
+                for item in payload:
+                    if isinstance(item, dict):
+                        yield item
+            elif isinstance(payload, dict):
+                if "records" in payload and isinstance(payload["records"], list):
+                    for item in payload["records"]:
+                        if isinstance(item, dict):
+                            yield item
+                else:
+                    yield payload
+            else:
+                raise ValueError(f"Unsupported JSON structure in {path}")
+        else:
+            raise ValueError(f"Unsupported input format: {path}")
+
+
+def write_dataframe(df: pd.DataFrame, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    suffix = path.suffix.lower()
+    if suffix == ".parquet":
+        df.to_parquet(path, index=False)
+    elif suffix == ".csv":
+        df.to_csv(path, index=False)
+    elif suffix == ".jsonl":
+        with path.open("w", encoding="utf-8") as fh:
+            for record in df.to_dict(orient="records"):
+                fh.write(json.dumps(record, ensure_ascii=False))
+                fh.write("\n")
+    else:
+        raise ValueError(f"Unsupported output format: {path}")
+
+
+def read_table(path: Path) -> pd.DataFrame:
+    suffix = path.suffix.lower()
+    if suffix == ".parquet":
+        return pd.read_parquet(path)
+    if suffix == ".csv":
+        return pd.read_csv(path)
+    if suffix == ".jsonl":
+        return pd.read_json(path, lines=True)
+    raise ValueError(f"Unsupported input format: {path}")
+
+
+__all__ = ["iter_raw_payloads", "read_table", "write_dataframe"]

--- a/trials_harvester/normalization/__init__.py
+++ b/trials_harvester/normalization/__init__.py
@@ -1,0 +1,22 @@
+"""Normalization registry dispatching per-source logic."""
+
+from __future__ import annotations
+
+from typing import Callable, Dict
+
+from .clinicaltrials_gov import normalize_study as normalize_ctg
+from .models import Trial
+
+_NORMALIZERS: Dict[str, Callable[[dict], Trial]] = {
+    "clinicaltrials_gov": normalize_ctg,
+}
+
+
+def normalize_record(source: str, record: dict) -> Trial:
+    key = source.lower().strip()
+    if key not in _NORMALIZERS:
+        raise ValueError(f"Unsupported source for normalisation: {source}")
+    return _NORMALIZERS[key](record)
+
+
+__all__ = ["normalize_record", "Trial"]

--- a/trials_harvester/normalization/clinicaltrials_gov.py
+++ b/trials_harvester/normalization/clinicaltrials_gov.py
@@ -1,0 +1,245 @@
+"""Normalisation helpers for ClinicalTrials.gov studies."""
+
+from __future__ import annotations
+
+import re
+from typing import Dict, Iterable, List, Optional
+
+from .models import Trial
+from .utils import (
+    normalize_countries,
+    normalize_phase,
+    normalize_status,
+    normalize_study_type,
+    parse_date,
+)
+
+_EUDRACT_RE = re.compile(r"\d{4}-\d{6}-\d{2}")
+_ISRCTN_RE = re.compile(r"ISRCTN\d+")
+
+
+def _as_list(value: object) -> List[str]:
+    if isinstance(value, list):
+        return [str(item) for item in value]
+    if isinstance(value, str):
+        return [value]
+    return []
+
+
+def _extract_secondary_ids(module: Dict[str, object]) -> List[str]:
+    secondary = module.get("SecondaryIdList")
+    if isinstance(secondary, dict):
+        return [str(item) for item in _as_list(secondary.get("SecondaryId"))]
+    return []
+
+
+def _extract_locations(module: Dict[str, object]) -> List[Dict[str, object]]:
+    location_list = module.get("LocationList")
+    if isinstance(location_list, dict):
+        locations = location_list.get("Location")
+        if isinstance(locations, list):
+            return [loc for loc in locations if isinstance(loc, dict)]
+    return []
+
+
+def _extract_interventions(module: Dict[str, object]) -> List[str]:
+    result: List[str] = []
+    intervention_list = module.get("InterventionList")
+    if isinstance(intervention_list, dict):
+        interventions = intervention_list.get("Intervention")
+        if isinstance(interventions, list):
+            for item in interventions:
+                if isinstance(item, dict):
+                    name = item.get("InterventionName") or item.get("Name")
+                    if isinstance(name, str) and name.strip():
+                        result.append(name.strip())
+    return result
+
+
+def _extract_conditions(module: Dict[str, object]) -> List[str]:
+    condition_list = module.get("ConditionList")
+    if isinstance(condition_list, dict):
+        return [
+            cond.strip()
+            for cond in _as_list(condition_list.get("Condition"))
+            if isinstance(cond, str) and cond.strip()
+        ]
+    return []
+
+
+def _unique(values: Iterable[str]) -> List[str]:
+    result: List[str] = []
+    for value in values:
+        if value and value not in result:
+            result.append(value)
+    return result
+
+
+def normalize_study(study: Dict[str, object]) -> Trial:
+    protocol = study.get("ProtocolSection", {}) if isinstance(study, dict) else {}
+    if not isinstance(protocol, dict):
+        protocol = {}
+
+    id_module = protocol.get("IdentificationModule", {})
+    status_module = protocol.get("StatusModule", {})
+    design_module = protocol.get("DesignModule", {})
+    sponsor_module = protocol.get("SponsorCollaboratorsModule", {})
+    conditions_module = protocol.get("ConditionsModule", {})
+    arms_module = protocol.get("ArmsInterventionsModule", {})
+    contacts_module = protocol.get("ContactsLocationsModule", {})
+    countries_module = protocol.get("LocationCountriesModule", {})
+
+    id_module = id_module if isinstance(id_module, dict) else {}
+    status_module = status_module if isinstance(status_module, dict) else {}
+    design_module = design_module if isinstance(design_module, dict) else {}
+    sponsor_module = sponsor_module if isinstance(sponsor_module, dict) else {}
+    conditions_module = conditions_module if isinstance(conditions_module, dict) else {}
+    arms_module = arms_module if isinstance(arms_module, dict) else {}
+    contacts_module = contacts_module if isinstance(contacts_module, dict) else {}
+    countries_module = countries_module if isinstance(countries_module, dict) else {}
+
+    nct_id = id_module.get("NCTId") if isinstance(id_module.get("NCTId"), str) else None
+    org_id = None
+    org_info = id_module.get("OrgStudyIdInfo")
+    if isinstance(org_info, dict):
+        org_id = org_info.get("OrgStudyId") if isinstance(org_info.get("OrgStudyId"), str) else None
+
+    source_id = nct_id or org_id
+    if not source_id:
+        raise ValueError("ClinicalTrials.gov study is missing a primary identifier")
+
+    secondary_ids = _extract_secondary_ids(id_module)
+    eudract_number = next((sid for sid in secondary_ids if _EUDRACT_RE.search(sid)), None)
+    isrctn = next((sid for sid in secondary_ids if _ISRCTN_RE.search(sid.upper())), None)
+
+    lead_sponsor = None
+    lead_info = sponsor_module.get("LeadSponsor")
+    if isinstance(lead_info, dict):
+        lead_sponsor = lead_info.get("LeadSponsorName") or lead_info.get("Name")
+        if isinstance(lead_sponsor, str):
+            lead_sponsor = lead_sponsor.strip()
+        else:
+            lead_sponsor = None
+
+    collaborators: List[str] = []
+    collab_list = sponsor_module.get("CollaboratorList")
+    if isinstance(collab_list, dict):
+        for entry in collab_list.get("Collaborator", []):
+            if isinstance(entry, dict):
+                name = entry.get("CollaboratorName") or entry.get("Name")
+                if isinstance(name, str) and name.strip():
+                    collaborators.append(name.strip())
+
+    sponsors_all = _unique([lead_sponsor or "", *collaborators])
+    if sponsors_all and not sponsors_all[0]:
+        sponsors_all = sponsors_all[1:]
+
+    enrollment_info = design_module.get("EnrollmentInfo") if isinstance(design_module, dict) else {}
+    enrollment = None
+    if isinstance(enrollment_info, dict):
+        raw_enrollment = enrollment_info.get("EnrollmentCount")
+        if isinstance(raw_enrollment, (int, float)):
+            enrollment = int(raw_enrollment)
+        elif isinstance(raw_enrollment, str):
+            try:
+                enrollment = int(raw_enrollment.replace(",", ""))
+            except ValueError:
+                enrollment = None
+
+    phase_list = []
+    phase_data = design_module.get("PhaseList")
+    if isinstance(phase_data, dict):
+        phase_list = _as_list(phase_data.get("Phase"))
+    phase = normalize_phase(phase_list)
+
+    overall_status = None
+    raw_status = status_module.get("OverallStatus")
+    if isinstance(raw_status, str):
+        overall_status = normalize_status(raw_status)
+
+    study_type = None
+    raw_type = design_module.get("StudyType") or study.get("StudyType")
+    if isinstance(raw_type, str):
+        study_type = normalize_study_type(raw_type)
+
+    locations = _extract_locations(contacts_module)
+    centers_count = len(locations) if locations else None
+    location_countries: List[str] = []
+    if locations:
+        for loc in locations:
+            country = loc.get("LocationCountry") if isinstance(loc, dict) else None
+            if isinstance(country, str) and country.strip():
+                location_countries.append(country.strip())
+    country_module_list = countries_module.get("LocationCountry")
+    if isinstance(country_module_list, list):
+        location_countries.extend(
+            [c for c in country_module_list if isinstance(c, str) and c.strip()]
+        )
+
+    conditions = _extract_conditions(conditions_module)
+    interventions = _extract_interventions(arms_module)
+
+    start_struct = status_module.get("StartDateStruct")
+    start_date = None
+    if isinstance(start_struct, dict):
+        start_date = parse_date(start_struct.get("StartDate"))
+    if not start_date:
+        start_date = parse_date(status_module.get("StartDate"))
+
+    primary_completion_struct = status_module.get("PrimaryCompletionDateStruct")
+    primary_completion_date = None
+    if isinstance(primary_completion_struct, dict):
+        primary_completion_date = parse_date(
+            primary_completion_struct.get("PrimaryCompletionDate")
+        )
+    if not primary_completion_date:
+        primary_completion_date = parse_date(status_module.get("PrimaryCompletionDate"))
+
+    completion_struct = status_module.get("CompletionDateStruct")
+    completion_date = None
+    if isinstance(completion_struct, dict):
+        completion_date = parse_date(completion_struct.get("CompletionDate"))
+    if not completion_date:
+        completion_date = parse_date(status_module.get("CompletionDate"))
+
+    last_update_struct = status_module.get("LastUpdatePostDateStruct")
+    last_updated_date = None
+    if isinstance(last_update_struct, dict):
+        last_updated_date = parse_date(last_update_struct.get("LastUpdatePostDate"))
+    if not last_updated_date:
+        last_updated_date = parse_date(status_module.get("LastUpdatePostDate"))
+
+    protocol_id = org_id
+
+    trial = Trial(
+        source="clinicaltrials_gov",
+        source_id=source_id,
+        public_title=id_module.get("BriefTitle") if isinstance(id_module.get("BriefTitle"), str) else None,
+        scientific_title=id_module.get("OfficialTitle")
+        if isinstance(id_module.get("OfficialTitle"), str)
+        else None,
+        sponsor_primary=lead_sponsor,
+        sponsors_all=sponsors_all,
+        phase=phase,
+        overall_status=overall_status,
+        study_type=study_type,
+        enrollment=enrollment,
+        centers_count=centers_count,
+        countries=normalize_countries(location_countries),
+        conditions=conditions,
+        interventions=_unique(interventions),
+        start_date=start_date,
+        primary_completion_date=primary_completion_date,
+        completion_date=completion_date,
+        nct_id=nct_id,
+        eudract_number=eudract_number,
+        isrctn=isrctn,
+        protocol_id=protocol_id,
+        last_updated_date=last_updated_date,
+        language="en",
+        raw_payload=study,
+    )
+    return trial
+
+
+__all__ = ["normalize_study"]

--- a/trials_harvester/normalization/models.py
+++ b/trials_harvester/normalization/models.py
@@ -1,0 +1,40 @@
+"""Data structures describing the unified trial schema."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Dict, List, Optional
+
+
+@dataclass
+class Trial:
+    source: str
+    source_id: str
+    public_title: Optional[str] = None
+    scientific_title: Optional[str] = None
+    sponsor_primary: Optional[str] = None
+    sponsors_all: List[str] = field(default_factory=list)
+    phase: Optional[str] = None
+    overall_status: Optional[str] = None
+    study_type: Optional[str] = None
+    enrollment: Optional[int] = None
+    centers_count: Optional[int] = None
+    countries: List[str] = field(default_factory=list)
+    conditions: List[str] = field(default_factory=list)
+    interventions: List[str] = field(default_factory=list)
+    start_date: Optional[str] = None
+    primary_completion_date: Optional[str] = None
+    completion_date: Optional[str] = None
+    nct_id: Optional[str] = None
+    eudract_number: Optional[str] = None
+    isrctn: Optional[str] = None
+    protocol_id: Optional[str] = None
+    last_updated_date: Optional[str] = None
+    language: Optional[str] = None
+    raw_payload: Dict[str, object] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, object]:
+        return asdict(self)
+
+
+__all__ = ["Trial"]

--- a/trials_harvester/normalization/utils.py
+++ b/trials_harvester/normalization/utils.py
@@ -1,0 +1,157 @@
+"""Helper functions shared by normalisers."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Iterable, List, Optional
+
+try:  # pragma: no cover - optional dependency
+    import pycountry
+except ImportError:  # pragma: no cover - optional dependency
+    pycountry = None
+
+from dateutil import parser as date_parser
+
+_FALLBACK_COUNTRIES = {
+    "UNITED STATES": "US",
+    "UNITED STATES OF AMERICA": "US",
+    "USA": "US",
+    "U.S.": "US",
+    "CANADA": "CA",
+    "RUSSIA": "RU",
+    "RUSSIAN FEDERATION": "RU",
+    "PEOPLES REPUBLIC OF CHINA": "CN",
+    "CHINA": "CN",
+    "GERMANY": "DE",
+    "FRANCE": "FR",
+    "UNITED KINGDOM": "GB",
+}
+
+
+def parse_date(value: Optional[str]) -> Optional[str]:
+    """Return a normalised ISO date string."""
+
+    if not value:
+        return None
+    try:
+        dt = date_parser.parse(value, default=datetime(1900, 1, 1))
+    except (ValueError, TypeError):
+        return None
+    return dt.strftime("%Y-%m-%d")
+
+
+_PHASE_PRIORITY = {"I": 1, "II": 2, "III": 3, "IV": 4, "NA": 99}
+_PHASE_MAP = {
+    "PHASE 1": ["I"],
+    "EARLY PHASE 1": ["I"],
+    "PHASE 2": ["II"],
+    "PHASE 3": ["III"],
+    "PHASE 4": ["IV"],
+    "PHASE 1/PHASE 2": ["I", "II"],
+    "PHASE 2/PHASE 3": ["II", "III"],
+    "PHASE 3/PHASE 4": ["III", "IV"],
+    "NOT APPLICABLE": ["NA"],
+    "NA": ["NA"],
+    "N/A": ["NA"],
+}
+
+
+def normalize_phase(phases: Iterable[str] | None) -> Optional[str]:
+    if not phases:
+        return None
+
+    buckets: List[str] = []
+    for raw in phases:
+        value = str(raw).strip()
+        if not value:
+            continue
+        upper = value.upper()
+        mapped = _PHASE_MAP.get(upper)
+        if mapped:
+            buckets.extend(mapped)
+            continue
+        if "/" in value:
+            sub = normalize_phase(value.split("/"))
+            if sub:
+                buckets.extend(sub.split("/"))
+            continue
+        buckets.append(value)
+
+    if not buckets:
+        return None
+
+    deduped: List[str] = []
+    for item in buckets:
+        if item not in deduped:
+            deduped.append(item)
+
+    deduped.sort(key=lambda x: _PHASE_PRIORITY.get(x, 50))
+    return "/".join(deduped)
+
+
+_STATUS_MAP = {
+    "NOT YET RECRUITING": "not_yet_recruiting",
+    "RECRUITING": "recruiting",
+    "ENROLLING BY INVITATION": "recruiting",
+    "ACTIVE, NOT RECRUITING": "active",
+    "COMPLETED": "completed",
+    "SUSPENDED": "suspended",
+    "TERMINATED": "terminated",
+    "WITHDRAWN": "terminated",
+    "UNKNOWN STATUS": "unknown",
+    "NO LONGER AVAILABLE": "terminated",
+    "AVAILABLE": "active",
+}
+
+
+def normalize_status(value: Optional[str]) -> Optional[str]:
+    if not value:
+        return None
+    return _STATUS_MAP.get(value.upper(), value.lower())
+
+
+def normalize_study_type(value: Optional[str]) -> Optional[str]:
+    if not value:
+        return None
+    stripped = value.strip()
+    return stripped.lower() if stripped else None
+
+
+def normalize_countries(values: Iterable[str] | None) -> List[str]:
+    if not values:
+        return []
+
+    countries: List[str] = []
+    for raw in values:
+        item = str(raw).strip()
+        if not item:
+            continue
+        code = None
+        upper = item.upper()
+        if pycountry is not None:  # pragma: no cover - depends on optional package
+            try:
+                country = pycountry.countries.lookup(item)
+            except LookupError:
+                country = None
+            if country is not None:
+                code = country.alpha_2.upper()
+        if code is None:
+            code = _FALLBACK_COUNTRIES.get(upper)
+        if code is None and len(item) == 2:
+            code = upper
+        if code:
+            countries.append(code)
+    deduped: List[str] = []
+    for code in countries:
+        if code not in deduped:
+            deduped.append(code)
+    return deduped
+
+
+__all__ = [
+    "normalize_countries",
+    "normalize_phase",
+    "normalize_status",
+    "normalize_study_type",
+    "parse_date",
+]

--- a/trials_harvester/sources/__init__.py
+++ b/trials_harvester/sources/__init__.py
@@ -1,0 +1,57 @@
+"""Source registry for fetcher implementations."""
+
+from __future__ import annotations
+
+from typing import Iterable, Optional, Type
+
+from .base import BaseFetcher, FetchConfig
+from .clinicaltrials_gov import ClinicalTrialsGovFetcher
+
+_FETCHER_ALIASES: dict[str, Type[BaseFetcher]] = {
+    "clinicaltrials": ClinicalTrialsGovFetcher,
+    "clinicaltrials_gov": ClinicalTrialsGovFetcher,
+    "ctg": ClinicalTrialsGovFetcher,
+}
+
+
+def _normalise_iterable(values: Optional[Iterable[str]]) -> Optional[tuple[str, ...]]:
+    if values is None:
+        return None
+    return tuple(v for v in values if v)
+
+
+def create_fetcher(
+    *,
+    source: str,
+    query: Optional[str] = None,
+    since: Optional[str] = None,
+    until: Optional[str] = None,
+    countries: Optional[Iterable[str]] = None,
+    sponsors: Optional[Iterable[str]] = None,
+    phases: Optional[Iterable[str]] = None,
+    statuses: Optional[Iterable[str]] = None,
+    batch_size: int = 100,
+    max_records: Optional[int] = None,
+) -> BaseFetcher:
+    """Instantiate a fetcher for ``source`` using the provided configuration."""
+
+    key = source.lower().strip()
+    if key not in _FETCHER_ALIASES:
+        raise ValueError(f"Unsupported source: {source}")
+
+    fetcher_cls = _FETCHER_ALIASES[key]
+    config = FetchConfig(
+        query=query,
+        since=since,
+        until=until,
+        countries=_normalise_iterable(countries),
+        sponsors=_normalise_iterable(sponsors),
+        phases=_normalise_iterable(phases),
+        statuses=_normalise_iterable(statuses),
+        batch_size=batch_size,
+        max_records=max_records,
+    )
+    return fetcher_cls(config)
+
+
+__all__ = ["BaseFetcher", "FetchConfig", "create_fetcher"]

--- a/trials_harvester/sources/base.py
+++ b/trials_harvester/sources/base.py
@@ -1,0 +1,49 @@
+"""Base classes for registry fetchers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Dict, Iterable, Iterator, Optional
+
+
+@dataclass
+class FetchConfig:
+    """Common configuration options shared by all fetchers."""
+
+    query: Optional[str] = None
+    since: Optional[str] = None
+    until: Optional[str] = None
+    countries: Optional[Iterable[str]] = None
+    sponsors: Optional[Iterable[str]] = None
+    phases: Optional[Iterable[str]] = None
+    statuses: Optional[Iterable[str]] = None
+    batch_size: int = 100
+    max_records: Optional[int] = None
+
+
+class BaseFetcher:
+    """Abstract fetcher returning raw registry records."""
+
+    source: str = ""
+
+    def __init__(self, config: FetchConfig) -> None:
+        self.config = config
+
+    # pragma: no cover - to be implemented by subclasses
+    def fetch(self) -> Iterator[Dict[str, object]]:  # type: ignore[override]
+        raise NotImplementedError
+
+    @staticmethod
+    def parse_date(value: str | None) -> datetime | None:
+        """Parse an ISO-like date string into :class:`datetime`."""
+
+        if not value:
+            return None
+        try:
+            return datetime.fromisoformat(value)
+        except ValueError:
+            return None
+
+
+__all__ = ["BaseFetcher", "FetchConfig"]

--- a/trials_harvester/sources/clinicaltrials_gov.py
+++ b/trials_harvester/sources/clinicaltrials_gov.py
@@ -1,0 +1,193 @@
+"""Fetcher implementation for ClinicalTrials.gov."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Dict, Iterator, Optional
+
+import requests
+
+from .. import __version__
+from .base import BaseFetcher, FetchConfig
+
+BASE_URL = "https://clinicaltrials.gov/api/query/full_studies"
+USER_AGENT = f"trials-harvester/{__version__}"
+REQUEST_DELAY = 0.5
+TRANSIENT_STATUS = {429, 500, 502, 503, 504}
+
+
+class ClinicalTrialsTemporaryError(RuntimeError):
+    """Raised when the API signals a transient problem."""
+
+
+@dataclass
+class _RequestParams:
+    expr: str
+    min_rank: int
+    max_rank: int
+
+
+class ClinicalTrialsGovFetcher(BaseFetcher):
+    """Stream :mod:`clinicaltrials.gov` studies via the public API."""
+
+    source = "clinicaltrials_gov"
+
+    def __init__(
+        self,
+        config: FetchConfig,
+        *,
+        session: Optional[requests.Session] = None,
+        request_delay: float = REQUEST_DELAY,
+        max_attempts: int = 5,
+    ) -> None:
+        super().__init__(config)
+        self.session = session or requests.Session()
+        self.session.headers.setdefault("User-Agent", USER_AGENT)
+        self.request_delay = request_delay
+        self.max_attempts = max(1, max_attempts)
+
+    def _build_expression(self) -> str:
+        parts: list[str] = []
+        if self.config.query:
+            parts.append(f"({self.config.query})")
+
+        if self.config.sponsors:
+            sponsor_clause = " OR ".join(
+                f'LEADSPONSOR:"{s}"' for s in self.config.sponsors
+            )
+            parts.append(f"({sponsor_clause})")
+
+        if self.config.countries:
+            country_clause = " OR ".join(
+                f'AREA[LocationCountry] {country}' for country in self.config.countries
+            )
+            parts.append(f"({country_clause})")
+
+        if self.config.phases:
+            phase_clause = " OR ".join(
+                f'PHASE:"{phase}"' for phase in self.config.phases
+            )
+            parts.append(f"({phase_clause})")
+
+        if self.config.statuses:
+            status_clause = " OR ".join(
+                f'OVERALLSTATUS:"{status}"' for status in self.config.statuses
+            )
+            parts.append(f"({status_clause})")
+
+        if not parts:
+            raise ValueError(
+                "At least one of --query/--sponsor/--country/--phase/--status must be provided"
+            )
+
+        return " AND ".join(parts)
+
+    def _filter_by_date(self, study: Dict[str, object]) -> bool:
+        since = self.parse_date(self.config.since)
+        until = self.parse_date(self.config.until)
+        protocol = study.get("ProtocolSection", {}) if isinstance(study, dict) else {}
+        status_module = protocol.get("StatusModule", {}) if isinstance(protocol, dict) else {}
+        last_update = None
+        if isinstance(status_module, dict):
+            struct = status_module.get("LastUpdatePostDateStruct")
+            if isinstance(struct, dict):
+                last_update = struct.get("LastUpdatePostDate")
+            if last_update is None:
+                last_update = status_module.get("LastUpdatePostDate")
+        parsed = None
+        if isinstance(last_update, str):
+            for fmt in ("%B %Y", "%B %d, %Y"):
+                try:
+                    parsed = datetime.strptime(last_update, fmt)
+                    break
+                except ValueError:
+                    continue
+            if parsed is None:
+                try:
+                    parsed = datetime.fromisoformat(last_update)
+                except ValueError:
+                    parsed = None
+        if since and parsed and parsed < since:
+            return False
+        if until and parsed and parsed > until:
+            return False
+        return True
+
+    def _build_params(self, min_rank: int, max_rank: int) -> _RequestParams:
+        expr = self._build_expression()
+        return _RequestParams(expr=expr, min_rank=min_rank, max_rank=max_rank)
+
+    def _perform_request(self, params: _RequestParams) -> Dict[str, object]:
+        attempt = 0
+        delay = 1.0
+        while True:
+            attempt += 1
+            try:
+                response = self.session.get(
+                    BASE_URL,
+                    params={
+                        "expr": params.expr,
+                        "min_rnk": params.min_rank,
+                        "max_rnk": params.max_rank,
+                        "fmt": "json",
+                    },
+                    timeout=60,
+                )
+            except requests.RequestException as exc:  # pragma: no cover - network error
+                if attempt >= self.max_attempts:
+                    raise ClinicalTrialsTemporaryError(str(exc)) from exc
+                time.sleep(min(60.0, delay))
+                delay *= 2
+                continue
+
+            if response.status_code in TRANSIENT_STATUS:
+                if attempt >= self.max_attempts:
+                    raise ClinicalTrialsTemporaryError(
+                        f"ClinicalTrials.gov returned {response.status_code}: {response.text[:200]}"
+                    )
+                time.sleep(min(60.0, delay))
+                delay *= 2
+                continue
+
+            response.raise_for_status()
+            return response.json()
+
+    def fetch(self) -> Iterator[Dict[str, object]]:
+        min_rank = 1
+        max_records = self.config.max_records
+        batch_size = max(1, self.config.batch_size)
+
+        while True:
+            upper = min_rank + batch_size - 1
+            if max_records is not None:
+                upper = min(upper, max_records)
+
+            params = self._build_params(min_rank, upper)
+            payload = self._perform_request(params)
+            data = payload.get("FullStudiesResponse", {})
+            studies = []
+            if isinstance(data, dict):
+                studies = data.get("FullStudies", [])  # type: ignore[assignment]
+            if not studies:
+                break
+
+            fetched = 0
+            for wrapper in studies:
+                study = wrapper.get("Study") if isinstance(wrapper, dict) else None
+                if isinstance(study, dict) and self._filter_by_date(study):
+                    yield study
+                    fetched += 1
+
+            if fetched == 0:
+                break
+
+            min_rank += batch_size
+            if max_records is not None and min_rank > max_records:
+                break
+
+            time.sleep(self.request_delay)
+
+
+__all__ = ["ClinicalTrialsGovFetcher"]


### PR DESCRIPTION
## Summary
- add the trials_harvester package with CLI entry points for fetching, normalizing, and deduplicating registry data
- implement a ClinicalTrials.gov fetcher with retry, batching, and date filtering plus a normalizer into the shared Trial schema
- provide IO helpers, deduplication logic, and unit tests with fixtures for the normalization pipeline

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd29fd1f14832ab0206094e00210f7