### PR TITLE
Add runbook notebook for parsers and data validation

### DIFF
--- a/parsers_runbook.ipynb
+++ b/parsers_runbook.ipynb
@@ -1,0 +1,311 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Runbook: запуск парсеров ClinicalTrials.gov и проверка данных",
+        "",
+        "Эта тетрадь служит единым чек-листом для инженеров данных. В ней собрано всё,",
+        "что необходимо для запуска парсеров ClinicalTrials.gov, прогонки тестов и быстрой",
+        "визуальной проверки собранных данных перед выгрузкой в дашборд."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 1. Подготовка окружения",
+        "",
+        "Работа ведётся из корня репозитория `coop_theory_diploma`. Перед первым запуском",
+        "рекомендуется создать виртуальное окружение и установить зависимости:",
+        "",
+        "```bash",
+        "python -m venv .venv",
+        "source .venv/bin/activate",
+        "pip install -r requirements.txt",
+        "```"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Создание виртуального окружения и установка зависимостей (опционально)\n",
+        "# Уберите символы комментария, чтобы выполнить команды. Активацию окружения\n",
+        "# выполняйте в терминале перед запуском тетради.\n",
+        "# !python -m venv .venv\n",
+        "# !source .venv/bin/activate  # выполните в терминале, чтобы активировать окружение\n",
+        "# !pip install -r requirements.txt\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "",
+        "# Проверим активную версию Python и расположение интерпретатора",
+        "import sys",
+        "print(sys.version)",
+        "print(sys.executable)",
+        ""
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "> 💡 Если зависимости уже установлены, повторный вызов `pip install` не требуется.\n",
+        "> Ячейка выше оставлена закомментированной для удобства."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 2. Запуск автотестов для парсеров",
+        "",
+        "В репозитории присутствуют тесты для нормализаторов и клиентских обёрток. Перед",
+        "сбором свежих данных стоит убедиться, что они проходят успешно."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "!pytest -q"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 3. Запуск высокоуровневых парсеров",
+        "",
+        "Далее можно перейти к сбору данных из ClinicalTrials.gov. Мы ограничиваем число",
+        "записей в демонстрационных примерах, чтобы минимизировать нагрузку на API.",
+        "При необходимости увеличьте `max_studies`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "",
+        "from data.parsers.clinical_trials import (",
+        "    ClinicalTrialsBySponsorParser,",
+        "    ClinicalTrialsExpressionParser,",
+        "    DEFAULT_SPONSORS,",
+        ")",
+        "from data.parsers.clinical_trials_api import ClinicalTrialsClient",
+        "import pandas as pd",
+        "",
+        "client = ClinicalTrialsClient()",
+        "",
+        "by_sponsor_parser = ClinicalTrialsBySponsorParser(",
+        "    sponsors=list(DEFAULT_SPONSORS)[:3],  # для ускорения берём первые три компании",
+        "    client=client,",
+        "    max_studies=50,",
+        "    batch_size=50,",
+        ")",
+        "",
+        "by_sponsor_result = by_sponsor_parser.parse()",
+        "by_sponsor_records = by_sponsor_result.payload[\"records\"]",
+        "",
+        "pd.DataFrame(by_sponsor_records)",
+        ""
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Помимо агрегирования по компаниям, можно запрашивать произвольные выражения,",
+        "например для валидации отдельных направлений исследований."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "",
+        "expression_parser = ClinicalTrialsExpressionParser(",
+        "    expr=\"oncology AND Recruiting\",",
+        "    client=client,",
+        "    max_studies=50,",
+        "    batch_size=50,",
+        ")",
+        "",
+        "expression_record = expression_parser.parse().payload[\"records\"][0]",
+        "expression_record",
+        ""
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 4. Быстрая визуальная проверка агрегатов",
+        "",
+        "После получения данных удобно посмотреть на распределения фаз и статусов, чтобы",
+        "убедиться, что парсеры вернули ожидаемые значения."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "",
+        "phase_counts = (",
+        "    pd.DataFrame(by_sponsor_records)",
+        "    .set_index(\"name\")[\"phase_counts\"]",
+        "    .apply(pd.Series)",
+        "    .fillna(0)",
+        "    .astype(int)",
+        "    .sort_index(axis=1)",
+        ")",
+        "",
+        "status_counts = (",
+        "    pd.DataFrame(by_sponsor_records)",
+        "    .set_index(\"name\")[\"status_counts\"]",
+        "    .apply(pd.Series)",
+        "    .fillna(0)",
+        "    .astype(int)",
+        "    .sort_index(axis=1)",
+        ")",
+        "",
+        "phase_counts",
+        ""
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "",
+        "import plotly.express as px",
+        "",
+        "phase_long = phase_counts.reset_index().melt(",
+        "    id_vars=\"name\", value_name=\"count\", var_name=\"phase\"",
+        ")",
+        "fig_phase = px.bar(",
+        "    phase_long,",
+        "    x=\"name\",",
+        "    y=\"count\",",
+        "    color=\"phase\",",
+        "    title=\"Распределение исследований по фазам\",",
+        ")",
+        "fig_phase.show()",
+        "",
+        "status_long = status_counts.reset_index().melt(",
+        "    id_vars=\"name\", value_name=\"count\", var_name=\"status\"",
+        ")",
+        "fig_status = px.bar(",
+        "    status_long,",
+        "    x=\"name\",",
+        "    y=\"count\",",
+        "    color=\"status\",",
+        "    title=\"Распределение исследований по статусам\",",
+        ")",
+        "fig_status.show()",
+        ""
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 5. Сохранение результата в JSON",
+        "",
+        "Для воспроизводимой выгрузки рекомендуется использовать готовый CLI-скрипт.",
+        "Пример ниже сохраняет небольшой набор данных в `data/clinical_trials_sample.json`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "",
+        "!python data_fetch/build_clinical_trials_dataset.py \\",
+        "    --sponsor Pfizer \\",
+        "    --sponsor BIOCAD \\",
+        "    --max-studies 100 \\",
+        "    --batch-size 50 \\",
+        "    --out data/clinical_trials_sample.json",
+        ""
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "",
+        "from pathlib import Path",
+        "import json",
+        "",
+        "output_path = Path(\"data/clinical_trials_sample.json\")",
+        "with output_path.open(\"r\", encoding=\"utf-8\") as fh:",
+        "    dataset = json.load(fh)",
+        "",
+        "dataset.keys()",
+        ""
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "",
+        "pd.DataFrame(dataset.get(\"sponsors\", []))",
+        ""
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 6. Следующие шаги",
+        "",
+        "* При необходимости расширьте список компаний или задайте собственное выражение",
+        "  для `ClinicalTrialsExpressionParser`.",
+        "* Результаты можно напрямую использовать в дашборде (`app/data.py`) либо",
+        "  дополнительно обработать в аналитических тетрадях.",
+        "* Не забывайте обновлять зависимости и периодически пересматривать тесты при",
+        "  доработках нормализации."
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.10"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a Jupyter runbook that documents environment setup, how to execute the ClinicalTrials.gov parsers, and how to run the associated pytest suite
- include cells for exporting parser output to JSON and quick visual checks of phase/status distributions
- add a commented command cell so environment setup commands can be run directly from the notebook when needed

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68dd2e79dc20832a8390af24dc6ebf15