### PR TITLE
Drop non-serializable marginals from core table rows

### DIFF
--- a/app/data.py
+++ b/app/data.py
@@ -174,8 +174,10 @@ def load_companies(dataset_path: Path | None = None) -> List[dict]:
             filtered = _filter_small_portfolios(companies)
             if filtered:
                 return filtered
+            if companies:
+                return companies
 
-    return _filter_small_portfolios(SYNTHETIC_COMPANIES)
+    return SYNTHETIC_COMPANIES
 
 
 __all__ = [

--- a/app/logic.py
+++ b/app/logic.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import itertools
 import math
-from typing import Dict, Iterable, List, Sequence
+import random
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional, Sequence
 
 Company = Dict[str, float]
 Parameters = Dict[str, float]
@@ -139,6 +141,169 @@ def shapley_values(
     return phi
 
 
+@dataclass
+class CoreViolation:
+    """Detailed information about the core deficit of a coalition."""
+
+    mask: int
+    coalition: List[str]
+    v_s: float
+    phi_s: float
+    deficit: float
+    deficit_share: float
+    size: int
+    violation: bool
+    marginals: Dict[str, float]
+
+
+@dataclass
+class CoreCheckResult:
+    """Container with diagnostics of the core conditions."""
+
+    efficient: bool
+    total_phi: float
+    grand_value: float
+    coalitions: List[CoreViolation]
+    sampled: bool = False
+
+
+def _popcount(mask: int) -> int:
+    count = 0
+    while mask:
+        mask &= mask - 1
+        count += 1
+    return count
+
+
+def _collect_masks(
+    n: int,
+    *,
+    r_max: Optional[int] = None,
+    sample: Optional[int] = None,
+) -> List[int]:
+    """Return the masks that should be evaluated for the core check."""
+
+    grand_mask = (1 << n) - 1
+    masks: List[int] = []
+    if sample and sample > 0:
+        rng = random.Random(42)
+        seen = {0, grand_mask}
+        # Draw unique masks until either we exhaust the space or reach sample.
+        while len(masks) < sample and len(seen) < (1 << n):
+            mask = rng.randrange(1, grand_mask)
+            if mask in seen:
+                continue
+            seen.add(mask)
+            if r_max:
+                size = _popcount(mask)
+                if not (size <= r_max or size >= n - r_max):
+                    continue
+            masks.append(mask)
+        return masks
+
+    for mask in range(1, grand_mask):
+        if r_max:
+            size = _popcount(mask)
+            if not (size <= r_max or size >= n - r_max):
+                continue
+        masks.append(mask)
+    return masks
+
+
+def core_diagnostics(
+    phi: Dict[str, float],
+    players: Sequence[str],
+    companies: Sequence[Company],
+    params: Parameters,
+    *,
+    eps_abs: float = 1e-6,
+    eps_rel: float = 1e-9,
+    r_max: Optional[int] = None,
+    sample: Optional[int] = None,
+) -> CoreCheckResult:
+    """Evaluate core conditions and return detailed diagnostics."""
+
+    players = list(players)
+    n = len(players)
+    if n == 0:
+        return CoreCheckResult(True, 0.0, 0.0, [], sampled=False)
+
+    index_of = {player: idx for idx, player in enumerate(players)}
+    grand_mask = (1 << n) - 1
+    v_cache: Dict[int, float] = {}
+
+    def mask_to_players(mask: int) -> List[str]:
+        return [player for player in players if mask >> index_of[player] & 1]
+
+    def value_of(mask: int) -> float:
+        if mask in v_cache:
+            return v_cache[mask]
+        if mask == 0:
+            v_cache[mask] = 0.0
+            return 0.0
+        subset = mask_to_players(mask)
+        val = coalition_savings(subset, companies, params)
+        v_cache[mask] = val
+        return val
+
+    total_phi = sum(phi.get(player, 0.0) for player in players)
+    grand_value = value_of(grand_mask)
+    scale = max(1.0, abs(grand_value))
+    eff_tol = max(eps_abs * scale, eps_rel * scale)
+    efficient = abs(total_phi - grand_value) <= eff_tol
+
+    coalitions: List[CoreViolation] = []
+    sampled = False
+    masks = _collect_masks(n, r_max=r_max, sample=sample)
+    if sample:
+        sampled = True
+
+    for mask in masks:
+        coalition_players = mask_to_players(mask)
+        size = len(coalition_players)
+        if size == 0 or size == n:
+            continue
+        v_s = value_of(mask)
+        phi_s = sum(phi.get(player, 0.0) for player in coalition_players)
+        tol = max(eps_abs * max(1.0, abs(v_s)), eps_rel * max(1.0, abs(v_s)))
+        deficit = v_s - phi_s
+        violation = deficit > tol
+        denominator = max(1e-9, abs(v_s))
+        deficit_share = deficit / denominator
+
+        marginals: Dict[str, float] = {}
+        if violation:
+            for player in coalition_players:
+                idx = index_of[player]
+                without_mask = mask & ~(1 << idx)
+                v_without = value_of(without_mask)
+                marginal = (v_s - v_without) - phi.get(player, 0.0)
+                marginals[player] = marginal
+
+        coalitions.append(
+            CoreViolation(
+                mask=mask,
+                coalition=coalition_players,
+                v_s=v_s,
+                phi_s=phi_s,
+                deficit=deficit,
+                deficit_share=deficit_share,
+                size=size,
+                violation=violation,
+                marginals=marginals,
+            )
+        )
+
+    coalitions.sort(key=lambda item: item.deficit, reverse=True)
+    return CoreCheckResult(
+        efficient=efficient,
+        total_phi=total_phi,
+        grand_value=grand_value,
+        coalitions=coalitions,
+        sampled=sampled,
+    )
+
+
 def core_check(
     phi: Dict[str, float],
     players: Sequence[str],
@@ -146,14 +311,6 @@ def core_check(
     params: Parameters,
 ) -> bool:
     """Return True if the Shapley point lies in the core."""
-    players = list(players)
-    grand = coalition_savings(players, companies, params)
-    if not math.isclose(sum(phi.values()), grand, rel_tol=1e-6, abs_tol=1e-6):
-        return False
-    for r in range(1, len(players)):
-        for subset in itertools.combinations(players, r):
-            lhs = sum(phi[player] for player in subset)
-            rhs = coalition_savings(subset, companies, params)
-            if lhs + 1e-9 < rhs:
-                return False
-    return True
+
+    result = core_diagnostics(phi, players, companies, params)
+    return result.efficient and not any(v.violation for v in result.coalitions)

--- a/app/pages/coop.py
+++ b/app/pages/coop.py
@@ -2,24 +2,46 @@
 
 from __future__ import annotations
 
-from typing import List
+import math
+from dataclasses import asdict
+from typing import List, Optional, Sequence, Union
 
 import dash
 from dash import Input, Output, State, callback, dcc, dash_table, html
+from dash.exceptions import PreventUpdate
 
-from ..logic import coalition_savings, core_check, expected_budget, shapley_values
+from ..logic import (
+    coalition_savings,
+    core_diagnostics,
+    expected_budget,
+    shapley_values,
+)
 
 
 dash.register_page(__name__, path="/coop", name="Кооперация и Шепли")
 
 
+CORE_TABLE_COLUMNS = [
+    {"name": "S (коалиция)", "id": "coalition"},
+    {"name": "|S|", "id": "size"},
+    {"name": "v(S)", "id": "vS"},
+    {"name": "Σφ(S)", "id": "phiS"},
+    {"name": "Δ(S)", "id": "deficit"},
+    {"name": "Δ(S)/v(S)", "id": "deficitShare"},
+    {"name": "mask", "id": "mask"},
+    {"name": "violation", "id": "violation"},
+    {"name": "group", "id": "is_group"},
+]
+
+
 layout = html.Div(
     [
+        dcc.Store(id="coop-analysis-store"),
         html.Div(
             [
                 html.H2("Кооперация и распределение экономии"),
                 html.P(
-                    "На этой странице оцениваем экономию большой коалиции и распределение по Шепли.",
+                    "На этой странице оцениваем экономию большой коалиции, распределение по Шепли и проверяем ядро.",
                     className="note",
                 ),
                 html.Div(
@@ -34,18 +56,115 @@ layout = html.Div(
                     ],
                     className="flex-row",
                 ),
-                html.Div(id="coop-summary", className="coop-summary", style={"marginTop": "12px"}),
-                dash_table.DataTable(
-                    id="coop-table",
-                    columns=[
-                        {"name": "Игрок", "id": "player"},
-                        {"name": "Solo бюджет, млн $", "id": "solo"},
-                        {"name": "Доля по Шепли, млн $", "id": "shapley"},
-                        {"name": "Новый бюджет, млн $", "id": "new_budget"},
+                dcc.Tabs(
+                    id="coop-tabs",
+                    value="distribution",
+                    children=[
+                        dcc.Tab(
+                            label="Распределение",
+                            value="distribution",
+                            children=[
+                                html.Div(
+                                    id="coop-summary",
+                                    className="coop-summary",
+                                    style={"marginTop": "12px"},
+                                ),
+                                dash_table.DataTable(
+                                    id="coop-table",
+                                    columns=[
+                                        {"name": "Игрок", "id": "player"},
+                                        {"name": "Solo бюджет, млн $", "id": "solo"},
+                                        {"name": "Доля по Шепли, млн $", "id": "shapley"},
+                                        {"name": "Новый бюджет, млн $", "id": "new_budget"},
+                                    ],
+                                    style_cell={"fontSize": 13},
+                                    style_header={"fontWeight": "600", "color": "#111827"},
+                                    style_table={"marginTop": "12px"},
+                                ),
+                            ],
+                        ),
+                        dcc.Tab(
+                            label="Ядро",
+                            value="core",
+                            children=[
+                                html.Div(
+                                    [
+                                        html.Button(
+                                            "Проверить ядро",
+                                            id="btn-check-core",
+                                            className="nav-link",
+                                            n_clicks=0,
+                                        ),
+                                        html.Button(
+                                            "Экспорт CSV",
+                                            id="btn-core-download",
+                                            className="nav-link",
+                                            n_clicks=0,
+                                            style={"marginLeft": "12px"},
+                                        ),
+                                        html.Span(
+                                            "Нажмите «Проверить ядро» — результаты будут обновляться автоматически.",
+                                            id="core-status",
+                                            className="note",
+                                            style={"marginLeft": "12px"},
+                                        ),
+                                    ],
+                                    className="flex-row",
+                                    style={"alignItems": "center", "marginTop": "12px"},
+                                ),
+                                html.Div(
+                                    [
+                                        dcc.Checklist(
+                                            id="core-options",
+                                            options=[
+                                                {"label": "Показывать только нарушения", "value": "only"},
+                                                {"label": "Группировать по размеру |S|", "value": "group"},
+                                            ],
+                                            value=["only"],
+                                            inline=True,
+                                            className="core-filter-checklist",
+                                        ),
+                                        dcc.Dropdown(
+                                            id="core-rmax",
+                                            placeholder="Макс. размер S",
+                                            clearable=True,
+                                            options=[
+                                                {"label": str(k), "value": k}
+                                                for k in range(1, 11)
+                                            ],
+                                            style={"width": "200px", "marginLeft": "12px"},
+                                        ),
+                                        dcc.Input(
+                                            id="core-topk",
+                                            type="number",
+                                            min=5,
+                                            max=200,
+                                            step=5,
+                                            value=20,
+                                            debounce=True,
+                                            style={"width": "120px", "marginLeft": "12px"},
+                                        ),
+                                    ],
+                                    className="flex-row",
+                                    style={"marginTop": "12px", "flexWrap": "wrap"},
+                                ),
+                                html.Div(id="core-summary", className="coop-summary", style={"marginTop": "12px"}),
+                                dash_table.DataTable(
+                                    id="core-violations-table",
+                                    columns=CORE_TABLE_COLUMNS,
+                                    hidden_columns=["mask", "violation", "is_group"],
+                                    style_cell={"fontSize": 13},
+                                    style_header={"fontWeight": "600", "color": "#111827"},
+                                    style_table={"marginTop": "12px"},
+                                    sort_action="native",
+                                    page_size=20,
+                                ),
+                                html.Div(id="core-heatmap", className="core-heatmap", style={"marginTop": "16px"}),
+                                dcc.Download(id="core-download"),
+                            ],
+                        ),
                     ],
-                    style_cell={"fontSize": 13},
-                    style_header={"fontWeight": "600", "color": "#111827"},
-                    style_table={"marginTop": "12px"},
+                    className="coop-tabs",
                 ),
             ],
             className="section-card",
@@ -68,26 +187,28 @@ def populate_options(companies):
 @callback(
     Output("coop-table", "data"),
     Output("coop-summary", "children"),
+    Output("coop-analysis-store", "data"),
     Input("btn-calc-coop", "n_clicks"),
+    Input("parameters-store", "data"),
     State("coop-selection", "value"),
     State("companies-store", "data"),
-    State("parameters-store", "data"),
-    prevent_initial_call=True,
 )
-def compute_cooperation(_, selected, companies, params):
+def compute_cooperation(_, params, selected, companies):
     selected = selected or []
     companies = companies or []
     params = params or {}
 
     if len(selected) < 2 or len(selected) > 7:
-        return [], html.Span(
+        message = html.Span(
             "Выберите от 2 до 7 компаний для расчёта Шепли (n! растёт быстро).",
             className="warn",
         )
+        return [], message, None
 
     phi = shapley_values(selected, companies, params)
     savings = coalition_savings(selected, companies, params)
-    is_core = core_check(phi, selected, companies, params)
+    diagnostics = core_diagnostics(phi, selected, companies, params)
+    is_core = diagnostics.efficient and not any(v.violation for v in diagnostics.coalitions)
 
     rows: List[dict] = []
     for player in selected:
@@ -115,4 +236,228 @@ def compute_cooperation(_, selected, companies, params):
         ]
     )
 
-    return rows, summary
+    core_payload = {
+        "players": selected,
+        "phi": {player: float(value) for player, value in phi.items()},
+        "grand_value": diagnostics.grand_value,
+        "total_phi": diagnostics.total_phi,
+        "efficient": diagnostics.efficient,
+        "sampled": diagnostics.sampled,
+        "coalitions": [asdict(item) for item in diagnostics.coalitions],
+    }
+
+    return rows, summary, core_payload
+
+
+def _format_number(value: float) -> str:
+    if math.isfinite(value):
+        if abs(value) >= 1:
+            return f"{value:,.2f}".replace(",", " ")
+        return f"{value:.4f}"
+    return "—"
+
+
+def _build_grouped_rows(rows: Sequence[dict]) -> List[dict]:
+    grouped: List[dict] = []
+    by_size: dict[int, List[dict]] = {}
+    for row in rows:
+        by_size.setdefault(row["size"], []).append(row)
+    for size in sorted(by_size):
+        coalition_rows = by_size[size]
+        grouped.append(
+            {
+                "coalition": f"|S| = {size} (коалиций: {len(coalition_rows)})",
+                "size": "",
+                "vS": "",
+                "phiS": "",
+                "deficit": "",
+                "deficitShare": "",
+                "mask": "",
+                "violation": False,
+                "is_group": True,
+            }
+        )
+        grouped.extend(coalition_rows)
+    return grouped
+
+
+def _build_heatmap(
+    players: Sequence[str],
+    coalitions: Sequence[dict],
+    top_k: int,
+) -> Union[html.Table, html.Div]:
+    violating = [row for row in coalitions if row.get("violation")]
+    if not violating:
+        return html.Div("Нарушающие коалиции отсутствуют.", className="note")
+
+    top = violating[: max(1, top_k)]
+    header = html.Thead(
+        html.Tr(
+            [html.Th("S\\i")] + [html.Th(player) for player in players],
+            className="core-heatmap-header",
+        )
+    )
+
+    body_rows: List[html.Tr] = []
+    for row in top:
+        coalition_players: List[str] = row.get("coalition", [])
+        marginals = row.get("marginals", {})
+        positive_marginals = [value for value in marginals.values() if value > 0]
+        max_margin = max(positive_marginals) if positive_marginals else 0.0
+        cells = [html.Td(", ".join(coalition_players) or "—", className="core-heatmap-label")]
+        for player in players:
+            in_coalition = player in coalition_players
+            base_alpha = 0.1 if in_coalition else 0.0
+            intensity = 0.0
+            if in_coalition and max_margin > 0:
+                intensity = max(0.0, marginals.get(player, 0.0)) / max_margin
+            alpha = base_alpha + 0.55 * intensity
+            style = {
+                "backgroundColor": f"rgba(220, 53, 69, {alpha:.2f})" if alpha > 0 else "transparent",
+            }
+            cells.append(html.Td("" if not in_coalition else "●", style=style))
+        body_rows.append(html.Tr(cells))
+
+    return html.Table([header, html.Tbody(body_rows)], className="core-heatmap-table")
+
+
+def _filter_coalitions(
+    payload: dict,
+    *,
+    r_max: Optional[int],
+) -> List[dict]:
+    coalitions = payload.get("coalitions") or []
+    players = payload.get("players") or []
+    n = len(players)
+    if not r_max:
+        return coalitions
+    return [
+        row
+        for row in coalitions
+        if row.get("size") <= r_max or row.get("size") >= n - r_max
+    ]
+
+
+@callback(
+    Output("core-summary", "children"),
+    Output("core-violations-table", "data"),
+    Output("core-violations-table", "style_data_conditional"),
+    Output("core-heatmap", "children"),
+    Input("btn-check-core", "n_clicks"),
+    Input("coop-analysis-store", "data"),
+    Input("core-options", "value"),
+    Input("core-rmax", "value"),
+    Input("core-topk", "value"),
+)
+def update_core_tab(n_clicks, payload, options, r_max, top_k):
+    if not n_clicks:
+        raise PreventUpdate
+    payload = payload or {}
+    players = payload.get("players") or []
+    coalitions = payload.get("coalitions") or []
+    if len(players) < 2 or not coalitions:
+        return (
+            html.Span("Нет данных для проверки ядра. Пересчитайте Шепли.", className="warn"),
+            [],
+            [],
+            html.Div("Недостаточно данных.", className="note"),
+        )
+
+    options = options or []
+    show_only = "only" in options
+    group_by = "group" in options
+    filtered = _filter_coalitions(payload, r_max=r_max)
+
+    rows: List[dict] = []
+    for row in filtered:
+        display_row = row.copy()
+        deficit_value = float(display_row.get("deficit", 0.0))
+        if show_only and deficit_value <= 0:
+            continue
+        display_row["_deficit_value"] = deficit_value
+        display_row["coalition"] = ", ".join(display_row.get("coalition", []))
+        display_row["vS"] = _format_number(float(display_row.get("v_s", display_row.get("vS", 0.0))))
+        display_row["phiS"] = _format_number(float(display_row.get("phi_s", display_row.get("phiS", 0.0))))
+        display_row["deficit"] = _format_number(deficit_value)
+        share = float(display_row.get("deficit_share", display_row.get("deficitShare", 0.0)))
+        display_row["deficitShare"] = "—" if not math.isfinite(share) else f"{share * 100:.1f}%"
+        display_row.setdefault("violation", bool(display_row.get("violation")))
+        display_row.setdefault("mask", display_row.get("mask", ""))
+        display_row.setdefault("is_group", False)
+        display_row.pop("marginals", None)
+        rows.append(display_row)
+
+    rows.sort(key=lambda item: float(item.get("_deficit_value", 0.0)), reverse=True)
+    data_rows = _build_grouped_rows(rows) if group_by else rows
+    for item in data_rows:
+        item.pop("_deficit_value", None)
+
+    style_data_conditional = [
+        {
+            "if": {"filter_query": "{violation} = True"},
+            "backgroundColor": "rgba(220, 53, 69, 0.12)",
+        },
+        {
+            "if": {"filter_query": "{is_group} = True"},
+            "fontWeight": "600",
+            "backgroundColor": "rgba(15, 23, 42, 0.05)",
+        },
+    ]
+
+    top_k = max(5, int(top_k or 20))
+    # Pass raw coalition data (without formatting) for the heatmap.
+    heatmap = _build_heatmap(players, filtered, top_k)
+
+    violations = [row for row in filtered if row.get("violation")]
+    total_deficit = sum(float(row.get("deficit", 0.0)) for row in violations if float(row.get("deficit", 0.0)) > 0)
+    summary_parts = [
+        f"Σφ = {_format_number(payload.get('total_phi', 0.0))}",
+        f"v(N) = {_format_number(payload.get('grand_value', 0.0))}",
+    ]
+    if payload.get("efficient"):
+        summary_parts.append("эффективность выполнена")
+    else:
+        summary_parts.append("эффективность нарушена")
+    summary_parts.append(f"Нарушений: {len(violations)}")
+    if total_deficit > 0:
+        summary_parts.append(f"ΣΔ(S) = {_format_number(total_deficit)}")
+    if payload.get("sampled"):
+        summary_parts.append("режим семплирования")
+
+    summary = html.Span("; ".join(summary_parts), className="note")
+
+    return summary, data_rows, style_data_conditional, heatmap
+
+
+@callback(
+    Output("core-download", "data"),
+    Input("btn-core-download", "n_clicks"),
+    State("core-violations-table", "data"),
+    prevent_initial_call=True,
+)
+def export_core_csv(n_clicks, table_data):
+    if not n_clicks:
+        raise PreventUpdate
+    table_data = table_data or []
+    rows = [row for row in table_data if not row.get("is_group")]
+    if not rows:
+        raise PreventUpdate
+
+    headers = ["S", "|S|", "v(S)", "Σφ(S)", "Δ(S)", "Δ(S)/v(S)"]
+    lines = [";".join(headers)]
+    for row in rows:
+        lines.append(
+            ";".join(
+                [
+                    row.get("coalition", ""),
+                    str(row.get("size", "")),
+                    str(row.get("vS", "")),
+                    str(row.get("phiS", "")),
+                    str(row.get("deficit", "")),
+                    str(row.get("deficitShare", "")),
+                ]
+            )
+        )
+
+    csv_data = "\n".join(lines)
+    return dict(content=csv_data, filename="core_violations.csv")


### PR DESCRIPTION
## Summary
- add detailed cooperative core diagnostics with deficit tracking and sampling helpers
- extend the cooperation page with a core analysis tab, filters, heatmap, and CSV export
- adjust dataset loading fallback to keep synthetic data when filters drop all entries
- fix the core violations DataTable configuration to hide metadata columns without invalid props
- prevent marginal deficit maps from being sent to the core violations DataTable rows so they remain serializable

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd9c5bfa38832a89d8fc58a63d7016